### PR TITLE
docs: community health files (CoC, Contributing, Security, templates)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1.
+
+The short version: be respectful, assume good faith, and keep technical
+discussions focused on the work. Personal attacks, harassment, and
+discriminatory comments are not welcome in issues, pull requests, or
+any other project channel.
+
+If something happens that violates this, please email the maintainer at
+**sean.galloway@outlook.com**. Reports will be handled privately.
+
+The full text of the Contributor Covenant v2.1 is available at:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Something doesn't behave the way the docs say it should.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. The more we can reproduce
+        the problem locally, the faster we can fix it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the unexpected behavior.
+      placeholder: When I call `APBSlave.start()` after a reset, it raises ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: |
+        A 20-line snippet beats a paragraph of description. If the bug only
+        shows up in a full testbench, link to a branch we can check out.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Full traceback or log
+      description: Please include the full output, not just the last line.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: framework-version
+    attributes:
+      label: cocotb-framework version
+      description: Output of `pip show cocotb-framework | grep Version` (or a commit SHA if installed from source).
+      placeholder: 0.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: 3.12.3
+    validations:
+      required: true
+
+  - type: input
+    id: simulator
+    attributes:
+      label: Simulator and version
+      description: Only if the bug surfaces in a sim run.
+      placeholder: verilator 5.024
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Ubuntu 24.04

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or design discussion
+    url: https://github.com/sean-galloway/RTLDesignSherpa-DV/discussions
+    about: For usage questions or "is this the right way to model X?" — please use Discussions.
+  - name: Parent project (RTL designs)
+    url: https://github.com/sean-galloway/RTLDesignSherpa
+    about: For issues with the RTL designs themselves (not the verification framework).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: A new BFM, scoreboard, or framework capability.
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. The more concrete the use case, the
+        easier it is to scope the work.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Describe the pain point or missing capability. If there's a workaround
+        you're using today, mention it — that helps us scope a real fix.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        Rough sketch is fine. Function signature, command flow, API shape, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Spec references, links to similar features in other projects, etc.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,30 @@
+name: Question or design discussion
+description: Usage question or "is this the right way to model X?"
+title: "[question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome — the answer may end up shaping the docs or
+        spawning a feature request. If this is more of an open-ended
+        discussion, consider opening a thread in
+        [Discussions](https://github.com/sean-galloway/RTLDesignSherpa-DV/discussions)
+        instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What have you tried so far?
+      description: |
+        Pointers to docs you've read, code you've looked at, or experiments
+        that didn't behave as expected.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for opening a PR! A few quick checks before you submit:
+
+- Is there an issue this PR addresses? Reference it with "Closes #N" or "Refs #N".
+- Did you run `pytest tests/unit/` and `ruff check src/`?
+- For BFM behavior changes, is there a test that fails without your patch
+  and passes with it?
+-->
+
+## Summary
+
+<!-- One or two sentences on what this changes and why. -->
+
+## Related issue
+
+Closes #
+
+## What changed
+
+<!-- Bullet points are fine. Keep it focused on observable behavior. -->
+
+-
+
+## Test plan
+
+- [ ] `pytest tests/unit/` passes locally
+- [ ] `ruff check src/` is clean
+- [ ] (If BFM behavior changed) A new test exercises the change
+
+## Notes for reviewers
+
+<!-- Anything that needs context, design tradeoffs, or follow-up items. -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Reporting Vulnerabilities
+
+If you find a problem in this project that should not be discussed in a
+public GitHub issue, please email **sean.galloway@outlook.com** with the
+details. Please do not open a public issue for the report itself.
+
+We aim to acknowledge new reports within a week.
+
+## Scope
+
+This project is a Python verification library (BFMs, scoreboards, and
+testbench helpers) used in simulation. It does not run as a network
+service, does not handle user credentials, and is not deployed as a
+production system. Reports most relevant to this project are:
+
+- Defects in BFM logic that could cause silent miscompares (i.e., a test
+  passes when it should fail).
+- Issues in build/install scripts or CI configuration.
+- Exposure of any credentials, tokens, or private data in the repo.
+
+Out of scope: simulation-only behavior that has no impact outside the
+test environment.
+
+## What to include
+
+- The version of `cocotb-framework` (or the commit SHA).
+- The Python and simulator versions you were running.
+- A minimal reproducer if one exists.
+- Your contact email for follow-up.
+
+## Supported versions
+
+The project follows the latest release on PyPI. Older minor versions
+are not patched; please upgrade to the latest before reporting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to RTLDesignSherpa-DV
+
+Thanks for your interest in improving the cocotb-framework. This repo is a
+reusable verification library: BFMs, scoreboards, and TB helpers used by
+the parent [RTLDesignSherpa](https://github.com/sean-galloway/RTLDesignSherpa)
+project and (we hope) by other RTL verification efforts.
+
+This guide covers the basics: how to file a useful bug report, propose a
+feature, and submit a pull request.
+
+---
+
+## Filing issues
+
+Before opening a new issue, please search [existing issues](https://github.com/sean-galloway/RTLDesignSherpa-DV/issues?q=is%3Aissue)
+for duplicates.
+
+There are three issue templates:
+
+- **Bug report** — something doesn't behave the way the docs say it should.
+- **Feature request** — a new BFM, scoreboard, or framework capability.
+- **Question / discussion** — usage questions, design discussions, "is this
+  the right way to model X?" The answer may end up shaping the docs or
+  spawning a feature request, so questions are welcome.
+
+For bug reports, include:
+
+- Python version, cocotb version (`pip show cocotb`), and simulator + version
+  (`verilator --version`, etc.)
+- A minimal reproducer if you can — even a 20-line snippet beats a paragraph
+  of description.
+- The full traceback / log, not just the last line.
+
+---
+
+## Development setup
+
+```bash
+git clone https://github.com/sean-galloway/RTLDesignSherpa-DV.git
+cd RTLDesignSherpa-DV
+python3 -m venv venv
+source venv/bin/activate
+pip install -e ".[dev,all]"
+
+# Optional: Tier 2 sim tests (need a Verilog simulator on PATH)
+pip install -e ".[sim]"
+```
+
+The repo ships an `env_python` script that activates the venv and wires
+`PYTHONPATH` so source edits are picked up without a reinstall:
+
+```bash
+source env_python
+```
+
+---
+
+## Running tests
+
+```bash
+# Tier 1 — pure-Python unit tests (no simulator required)
+pytest tests/unit/ -v
+
+# Tier 2 — cocotb sim tests (need verilator + the RTL repo)
+pytest tests/sim/ -v
+```
+
+If you add new BFM behavior, please add a test that exercises it. If you
+fix a bug, please add a regression test that fails before your fix and
+passes after.
+
+---
+
+## Code style
+
+- Python: [ruff](https://github.com/astral-sh/ruff) — run `ruff check src/`
+  before committing. The repo's `pyproject.toml` defines the active rule
+  set.
+- Line length: 120 (per `pyproject.toml`).
+- Prefer small, focused commits with a clear `type(scope): description`
+  subject line. Examples from the existing log:
+
+  ```
+  feat(dfi): MVP foundation — signal envelope, packets, field configs
+  fix(axi4): correct handling of NARROW burst sizes
+  chore(ci): bump GitHub Actions to Node 24 versions
+  ```
+
+Types we use: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+
+---
+
+## Pull request workflow
+
+1. **Open an issue first** for anything larger than a typo or a one-line
+   fix. This lets us agree on the approach before you sink time into code.
+2. Fork the repo and create a feature branch off `main`:
+   ```
+   git checkout -b feat/short-description
+   ```
+3. Make your change. Add tests. Run `pytest` and `ruff check`.
+4. Push and open a PR against `main`. Reference the issue (`Closes #N` or
+   `Refs #N`).
+5. CI runs automatically. Please keep it green — a red PR is much harder
+   to review.
+
+PRs that touch BFM semantics or break existing test interfaces will get
+extra scrutiny, since downstream projects depend on this repo as a pinned
+version.
+
+---
+
+## Code of Conduct
+
+By participating, you agree to abide by the project's
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+---
+
+## License
+
+This project is MIT-licensed. Contributions are accepted under the same
+terms — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Adds the standard GitHub community-health files so first-time contributors trust the repo is maintained and know how to file useful issues. None of these are strictly required to ship code — they're the green checkmarks under **Insights → Community Standards**.

## What's included

- **CONTRIBUTING.md** — dev setup, test workflow, PR process, code style notes
- **CODE_OF_CONDUCT.md** — short Contributor Covenant v2.1 reference + contact
- **SECURITY.md** — vuln-report contact, scoped to a verification library (not a generic web-service template)
- **PULL_REQUEST_TEMPLATE.md** — summary + test-plan checklist
- **ISSUE_TEMPLATE/**
  - `bug_report.yml` — versions + reproducer + traceback
  - `feature_request.yml` — problem / proposal / alternatives
  - `question.yml` — usage / design discussion
  - `config.yml` — disables blank issues, links Discussions + parent RTL repo

## Follow-up (repo settings, not in this PR)

**Discussions tab** needs to be enabled in Settings → Features → Discussions, otherwise the link in `config.yml` (to `/discussions`) will 404. Worth doing right after merging this.

## Test plan

- [x] All files render correctly on the branch (GitHub renders `.md` + the `.yml` issue forms natively)
- [ ] After merge, visit **Insights → Community Standards** and confirm all five checkmarks are green
- [ ] After merge, open a test issue to confirm the templates show up in the picker
- [ ] After merge, enable Discussions in repo Settings

## Summary by Sourcery

Add standard community health and contribution documentation to guide contributors and structure project interactions.

Documentation:
- Add CONTRIBUTING guide covering issue filing, development setup, testing, style, and PR workflow.
- Add Code of Conduct referencing Contributor Covenant and maintainer contact details.
- Add security policy describing in-scope vulnerabilities, reporting process, and supported versions.

Chores:
- Introduce structured GitHub issue templates for bugs, feature requests, and questions, plus configuration to disable blank issues and point to Discussions.
- Add a pull request template to standardize change descriptions and test plans.