### PR TITLE
DFI v2.1 BFM MVP: chassis, master, slave, monitor (issue #16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ site/
 # OS
 .DS_Store
 Thumbs.db
+
+# cocotb sim build artifacts
+tests/sim/local_sim_build/
+tests/sim/logs/

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -26,6 +26,7 @@ from .dfi_field_configs import (
     read_data_field_config,
     write_data_field_config,
 )
+from .dfi_monitor import DFIMonitor
 from .dram_state import (
     AddressMapping,
     Bank,
@@ -75,6 +76,7 @@ __all__ = [
     "is_supported_pair",
     "SUPPORTED_MEMORY_BY_VERSION",
     "DFIBase",
+    "DFIMonitor",
     "AddressMapping",
     "Bank",
     "BankState",

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -20,6 +20,7 @@ the next commit; this module ships the foundation (signal envelope,
 packet types, field configs) plus Tier 1 unit tests.
 """
 
+from .dfi_base import DFIBase
 from .dfi_field_configs import (
     command_field_config,
     read_data_field_config,
@@ -73,6 +74,7 @@ __all__ = [
     "validate_configuration",
     "is_supported_pair",
     "SUPPORTED_MEMORY_BY_VERSION",
+    "DFIBase",
     "AddressMapping",
     "Bank",
     "BankState",

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -21,7 +21,7 @@ packet types, field configs) plus Tier 1 unit tests.
 """
 
 from .dfi_field_configs import (
-    control_field_config,
+    command_field_config,
     read_data_field_config,
     write_data_field_config,
 )
@@ -32,11 +32,13 @@ from .dfi_packet import (
     DRAMCommand,
 )
 from .dfi_signals import (
+    SUPPORTED_MEMORY_BY_VERSION,
     DFIVersion,
     MemoryType,
     SignalDirection,
     SignalSpec,
     SubInterface,
+    is_supported_pair,
     optional_signal_names,
     required_signal_names,
     signals_for,
@@ -53,11 +55,13 @@ __all__ = [
     "DFIWriteDataPacket",
     "DFIReadDataPacket",
     "DRAMCommand",
-    "control_field_config",
+    "command_field_config",
     "write_data_field_config",
     "read_data_field_config",
     "signals_for",
     "required_signal_names",
     "optional_signal_names",
     "validate_configuration",
+    "is_supported_pair",
+    "SUPPORTED_MEMORY_BY_VERSION",
 ]

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -25,6 +25,15 @@ from .dfi_field_configs import (
     read_data_field_config,
     write_data_field_config,
 )
+from .dram_state import (
+    AddressMapping,
+    Bank,
+    BankState,
+    DramStateModel,
+    ViolationCategory,
+    ViolationPolicy,
+)
+from .jedec_timings import JedecTimings, builtin_timings, load_timings, ns_to_cycles
 from .dfi_packet import (
     DFIControlPacket,
     DFIReadDataPacket,
@@ -64,4 +73,14 @@ __all__ = [
     "validate_configuration",
     "is_supported_pair",
     "SUPPORTED_MEMORY_BY_VERSION",
+    "AddressMapping",
+    "Bank",
+    "BankState",
+    "DramStateModel",
+    "ViolationCategory",
+    "ViolationPolicy",
+    "JedecTimings",
+    "builtin_timings",
+    "load_timings",
+    "ns_to_cycles",
 ]

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -26,6 +26,7 @@ from .dfi_field_configs import (
     read_data_field_config,
     write_data_field_config,
 )
+from .dfi_master_mc import DFIMasterMC
 from .dfi_monitor import DFIMonitor
 from .dram_state import (
     AddressMapping,
@@ -76,6 +77,7 @@ __all__ = [
     "is_supported_pair",
     "SUPPORTED_MEMORY_BY_VERSION",
     "DFIBase",
+    "DFIMasterMC",
     "DFIMonitor",
     "AddressMapping",
     "Bank",

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -28,6 +28,7 @@ from .dfi_field_configs import (
 )
 from .dfi_master_mc import DFIMasterMC
 from .dfi_monitor import DFIMonitor
+from .dfi_slave_phy import DFISlavePHY
 from .dram_state import (
     AddressMapping,
     Bank,
@@ -79,6 +80,7 @@ __all__ = [
     "DFIBase",
     "DFIMasterMC",
     "DFIMonitor",
+    "DFISlavePHY",
     "AddressMapping",
     "Bank",
     "BankState",

--- a/src/CocoTBFramework/components/dfi/__init__.py
+++ b/src/CocoTBFramework/components/dfi/__init__.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""DDR PHY Interface (DFI) BFMs (issue #16).
+
+Public API:
+
+- :class:`DFIVersion`, :class:`MemoryType`, :class:`SubInterface` —
+  enums for the version/memory/sub-interface envelope
+- :class:`DFIControlPacket`, :class:`DFIWriteDataPacket`,
+  :class:`DFIReadDataPacket` — per-sub-interface transaction types
+- :class:`DRAMCommand` — high-level DRAM command codes
+- :func:`control_field_config`, :func:`write_data_field_config`,
+  :func:`read_data_field_config` — packet field configs for the BFMs
+- :func:`signals_for`, :func:`required_signal_names`,
+  :func:`optional_signal_names` — signal-envelope helpers
+
+The actual BFM classes (DFIMasterMC, DFISlavePHY, DFIMonitor) land in
+the next commit; this module ships the foundation (signal envelope,
+packet types, field configs) plus Tier 1 unit tests.
+"""
+
+from .dfi_field_configs import (
+    control_field_config,
+    read_data_field_config,
+    write_data_field_config,
+)
+from .dfi_packet import (
+    DFIControlPacket,
+    DFIReadDataPacket,
+    DFIWriteDataPacket,
+    DRAMCommand,
+)
+from .dfi_signals import (
+    DFIVersion,
+    MemoryType,
+    SignalDirection,
+    SignalSpec,
+    SubInterface,
+    optional_signal_names,
+    required_signal_names,
+    signals_for,
+    validate_configuration,
+)
+
+__all__ = [
+    "DFIVersion",
+    "MemoryType",
+    "SubInterface",
+    "SignalDirection",
+    "SignalSpec",
+    "DFIControlPacket",
+    "DFIWriteDataPacket",
+    "DFIReadDataPacket",
+    "DRAMCommand",
+    "control_field_config",
+    "write_data_field_config",
+    "read_data_field_config",
+    "signals_for",
+    "required_signal_names",
+    "optional_signal_names",
+    "validate_configuration",
+]

--- a/src/CocoTBFramework/components/dfi/dfi_base.py
+++ b/src/CocoTBFramework/components/dfi/dfi_base.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""DFI BFM chassis (issue #16).
+
+:class:`DFIBase` is the shared configuration + sub-interface registry
+that :class:`DFIMasterMC`, :class:`DFISlavePHY`, and :class:`DFIMonitor`
+all inherit. It holds nothing cocotb-specific — the wire-layer drive
+and capture code lives in the subclasses — so it's pure-Python testable
+in isolation.
+
+Responsibilities:
+  - validate the (dfi_version, memory_type) pair against the spec envelope
+  - own the set of enabled sub-interfaces (MVP default: command +
+    write_data + read_data)
+  - dispatch to the right ``*_field_config`` builder for each
+    sub-interface
+  - hold the address mapping + timings the slave/monitor will consume
+  - maintain a free-running DFI cycle counter the subclasses advance
+"""
+
+from __future__ import annotations
+
+from typing import FrozenSet, Optional
+
+from ..shared.field_config import FieldConfig
+from .dfi_field_configs import (
+    command_field_config,
+    read_data_field_config,
+    write_data_field_config,
+)
+from .dfi_signals import (
+    MVP_SUB_INTERFACES,
+    DFIVersion,
+    MemoryType,
+    SubInterface,
+    is_supported_pair,
+)
+from .dram_state import AddressMapping
+from .jedec_timings import JedecTimings
+
+
+_FIELD_CONFIG_BUILDERS = {
+    SubInterface.COMMAND: command_field_config,
+    SubInterface.WRITE_DATA: write_data_field_config,
+    SubInterface.READ_DATA: read_data_field_config,
+}
+
+
+class DFIBase:
+    """Shared chassis for the three DFI BFM roles.
+
+    Subclasses (``DFIMasterMC`` / ``DFISlavePHY`` / ``DFIMonitor``)
+    add the cocotb signal-binding and per-role drive/capture logic;
+    everything they need to *configure* themselves lives here.
+
+    The ``tick()`` method advances the cycle counter — subclasses
+    call it once per DFI clock edge so the timing checker and the
+    BFM share a clock domain.
+    """
+
+    def __init__(
+        self,
+        *,
+        dfi_version: DFIVersion,
+        memory_type: MemoryType,
+        timings: JedecTimings,
+        mapping: AddressMapping,
+        sub_interfaces: Optional[FrozenSet[SubInterface]] = None,
+    ):
+        if not is_supported_pair(dfi_version, memory_type):
+            raise ValueError(
+                f"DFI version {dfi_version.value} + memory type "
+                f"{memory_type.value} is not supported (see "
+                f"SUPPORTED_MEMORY_BY_VERSION for the envelope)"
+            )
+
+        self.dfi_version = dfi_version
+        self.memory_type = memory_type
+        self.timings = timings
+        self.mapping = mapping
+        self.enabled_sub_interfaces: FrozenSet[SubInterface] = (
+            sub_interfaces if sub_interfaces is not None else MVP_SUB_INTERFACES
+        )
+        self.cycle = 0
+
+    # ----- Cycle accounting -----
+
+    def tick(self) -> None:
+        """Advance the DFI clock by one cycle."""
+        self.cycle += 1
+
+    # ----- Field-config dispatch -----
+
+    def field_config_for(self, sub: SubInterface) -> FieldConfig:
+        """Return the ``FieldConfig`` for ``sub``, sized to this chassis."""
+        if sub not in self.enabled_sub_interfaces:
+            raise ValueError(
+                f"sub-interface {sub.value} not enabled "
+                f"(enabled: {[s.value for s in self.enabled_sub_interfaces]})"
+            )
+        builder = _FIELD_CONFIG_BUILDERS.get(sub)
+        if builder is None:
+            raise ValueError(
+                f"no field-config builder registered for sub-interface "
+                f"{sub.value} (MVP supports COMMAND / WRITE_DATA / READ_DATA)"
+            )
+        return builder(
+            version=self.dfi_version,
+            memory_type=self.memory_type,
+            bank_width=self.bank_width,
+            addr_width=max(self.row_width, self.col_width),
+        ) if sub == SubInterface.COMMAND else builder(
+            version=self.dfi_version,
+            memory_type=self.memory_type,
+        )
+
+    # ----- Address-width derivations -----
+
+    @property
+    def bank_width(self) -> int:
+        """Bit width of the bank field, derived from the mapping geometry."""
+        return self.mapping._widths["bank"]
+
+    @property
+    def row_width(self) -> int:
+        return self.mapping._widths["row"]
+
+    @property
+    def col_width(self) -> int:
+        return self.mapping._widths["col"]
+
+    @property
+    def rank_width(self) -> int:
+        return self.mapping._widths["rank"]

--- a/src/CocoTBFramework/components/dfi/dfi_field_configs.py
+++ b/src/CocoTBFramework/components/dfi/dfi_field_configs.py
@@ -82,7 +82,7 @@ def _build_for(
 # ----------------------------------------------------------------------
 
 
-def control_field_config(
+def command_field_config(
     *,
     version: DFIVersion = DFIVersion.V2_1,
     memory_type: MemoryType = MemoryType.DDR3,
@@ -91,14 +91,18 @@ def control_field_config(
     cs_width: int = 1,
     ctrl_width: int = 1,
 ) -> FieldConfig:
-    """FieldConfig for the DFI Control Interface."""
+    """FieldConfig for the DFI Command (a.k.a. Control) Interface.
+
+    v6.0 renamed the interface and the address bus
+    (``dfi_address`` → ``dfi_cmdaddr``); the role is unchanged.
+    """
     widths = _resolve_widths(
         addr_width=addr_width,
         bank_width=bank_width,
         cs_width=cs_width,
         ctrl_width=ctrl_width,
     )
-    return _build_for(SubInterface.CONTROL, version, memory_type, widths)
+    return _build_for(SubInterface.COMMAND, version, memory_type, widths)
 
 
 def write_data_field_config(

--- a/src/CocoTBFramework/components/dfi/dfi_field_configs.py
+++ b/src/CocoTBFramework/components/dfi/dfi_field_configs.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""FieldConfig builders for the three MVP DFI sub-interfaces (issue #16).
+
+Each builder returns a ``FieldConfig`` populated with the fields that
+actually exist for the requested ``(memory_type, sub_interface)``
+combination. The width-keyword sentinels in ``dfi_signals`` are
+resolved against the caller-supplied width parameters.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..shared.field_config import FieldConfig, FieldDefinition
+from .dfi_signals import (
+    WIDTH_ADDR,
+    WIDTH_BANK,
+    WIDTH_CS,
+    WIDTH_CTRL,
+    WIDTH_DATA,
+    WIDTH_DATA_DIV8,
+    WIDTH_DATA_EN,
+    WIDTH_RD_VALID,
+    DFIVersion,
+    MemoryType,
+    SubInterface,
+    signals_for,
+)
+
+
+def _resolve_widths(
+    *,
+    addr_width: int = 16,
+    bank_width: int = 3,
+    cs_width: int = 1,
+    ctrl_width: int = 1,
+    data_width: int = 64,
+    data_enable_width: int = 1,
+    rd_valid_width: int = 1,
+) -> Dict[str, int]:
+    """Map width-keyword sentinels (from ``dfi_signals``) to concrete ints.
+
+    All defaults match a typical DDR3 ×4 single-rank config (16-bit
+    address, 3-bit bank, single chip select, 64-bit data path).
+    """
+    return {
+        WIDTH_ADDR: addr_width,
+        WIDTH_BANK: bank_width,
+        WIDTH_CS: cs_width,
+        WIDTH_CTRL: ctrl_width,
+        WIDTH_DATA: data_width,
+        WIDTH_DATA_EN: data_enable_width,
+        WIDTH_RD_VALID: rd_valid_width,
+        WIDTH_DATA_DIV8: max(1, data_width // 8),
+    }
+
+
+def _build_for(
+    sub_interface: SubInterface,
+    version: DFIVersion,
+    memory_type: MemoryType,
+    widths: Dict[str, int],
+) -> FieldConfig:
+    """Walk the signal catalog for one sub-interface and emit a FieldConfig."""
+    cfg = FieldConfig()
+    for spec in signals_for(version, memory_type, frozenset({sub_interface})):
+        bits = widths[spec.width_key]
+        cfg.add_field(FieldDefinition(
+            name=spec.name,
+            bits=bits,
+            default=0,
+            format="hex",
+            description=spec.description,
+        ))
+    return cfg
+
+
+# ----------------------------------------------------------------------
+# Public builders — one per MVP sub-interface
+# ----------------------------------------------------------------------
+
+
+def control_field_config(
+    *,
+    version: DFIVersion = DFIVersion.V2_1,
+    memory_type: MemoryType = MemoryType.DDR3,
+    addr_width: int = 16,
+    bank_width: int = 3,
+    cs_width: int = 1,
+    ctrl_width: int = 1,
+) -> FieldConfig:
+    """FieldConfig for the DFI Control Interface."""
+    widths = _resolve_widths(
+        addr_width=addr_width,
+        bank_width=bank_width,
+        cs_width=cs_width,
+        ctrl_width=ctrl_width,
+    )
+    return _build_for(SubInterface.CONTROL, version, memory_type, widths)
+
+
+def write_data_field_config(
+    *,
+    version: DFIVersion = DFIVersion.V2_1,
+    memory_type: MemoryType = MemoryType.DDR3,
+    data_width: int = 64,
+    data_enable_width: int = 1,
+) -> FieldConfig:
+    """FieldConfig for the DFI Write Data Interface."""
+    widths = _resolve_widths(
+        data_width=data_width,
+        data_enable_width=data_enable_width,
+    )
+    return _build_for(SubInterface.WRITE_DATA, version, memory_type, widths)
+
+
+def read_data_field_config(
+    *,
+    version: DFIVersion = DFIVersion.V2_1,
+    memory_type: MemoryType = MemoryType.DDR3,
+    data_width: int = 64,
+    data_enable_width: int = 1,
+    rd_valid_width: int = 1,
+) -> FieldConfig:
+    """FieldConfig for the DFI Read Data Interface."""
+    widths = _resolve_widths(
+        data_width=data_width,
+        data_enable_width=data_enable_width,
+        rd_valid_width=rd_valid_width,
+    )
+    return _build_for(SubInterface.READ_DATA, version, memory_type, widths)

--- a/src/CocoTBFramework/components/dfi/dfi_master_mc.py
+++ b/src/CocoTBFramework/components/dfi/dfi_master_mc.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""MC-side DFI driver — primitive API (issue #16).
+
+:class:`DFIMasterMC` is a thin cocotb_bus.BusDriver subclass that
+exposes one async primitive per DFI command (``activate``, ``read``,
+``write``, ``precharge``, ``refresh``) plus a ``write_data`` beat
+driver. Each primitive drives the wire for one clock cycle and then
+returns the bus to deselected idle.
+
+The MVP API is deliberately primitive — no transaction queue, no
+randomizer, no auto-spacing for tRCD / CWL. The caller is expected
+to insert delays via ``nop(cycles=…)`` between primitives. This makes
+the BFM a faithful "what you drive is what hits the wire" model for
+verifying MC RTL, and lets the slave-side timing checker
+(:class:`DramStateModel`) catch any caller-induced violations.
+
+For DDR3 / DDR2 / DDR1 the (ras_n, cas_n, we_n) encoding follows
+JESD79-3F Table 67 — same table the monitor decodes against, so a
+master + monitor pair round-trips cleanly across the shim.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cocotb.triggers import RisingEdge
+from cocotb_bus.drivers import BusDriver
+
+from .dfi_monitor import _COMMAND_SIGNALS, _READ_DATA_SIGNALS, _WRITE_DATA_SIGNALS
+
+
+class DFIMasterMC(BusDriver):
+    """MC-side DFI driver.
+
+    Args:
+        entity:   The cocotb DUT handle.
+        clock:    The DFI clock signal.
+        side:     Currently only ``"mc"`` (the MC drives the master role).
+                  The argument exists for symmetry with :class:`DFIMonitor`.
+        title:    Optional title for log messages.
+    """
+
+    _signals = list(_COMMAND_SIGNALS) + list(_WRITE_DATA_SIGNALS) + list(_READ_DATA_SIGNALS)
+    _optional_signals: list = []
+
+    def __init__(
+        self,
+        entity,
+        clock,
+        side: str = "mc",
+        title: Optional[str] = None,
+        **kwargs,
+    ):
+        if side != "mc":
+            raise ValueError(
+                f"DFIMasterMC drives the MC side only, got side={side!r}"
+            )
+        self.side = side
+        self.title = title or "DFIMasterMC"
+
+        BusDriver.__init__(self, entity, f"{side}_dfi", clock, **kwargs)
+        self.clock = clock
+        self.log = self.entity._log
+        self._init_idle()
+
+    # ----- Idle drive -----
+
+    def _init_idle(self) -> None:
+        """Drive all MC-side outputs to deselected idle.
+
+        Called once at construction. The primitives below return signals
+        to this state after each transaction so the bus naturally idles
+        between commands.
+        """
+        self.bus.address.value = 0
+        self.bus.bank.value = 0
+        self.bus.cs_n.value = 1   # deselected (active low)
+        self.bus.ras_n.value = 1
+        self.bus.cas_n.value = 1
+        self.bus.we_n.value = 1
+        self.bus.cke.value = 1    # clock enabled
+        self.bus.odt.value = 0
+        self.bus.reset_n.value = 1
+        self.bus.wrdata.value = 0
+        self.bus.wrdata_en.value = 0
+        self.bus.wrdata_mask.value = 0
+        self.bus.rddata_en.value = 0
+
+    # ----- Internal: drive a 1-cycle command pulse -----
+
+    async def _drive_command(
+        self,
+        *,
+        ras_n: int,
+        cas_n: int,
+        we_n: int,
+        bank: int = 0,
+        address: int = 0,
+    ) -> None:
+        self.bus.cs_n.value = 0
+        self.bus.ras_n.value = ras_n
+        self.bus.cas_n.value = cas_n
+        self.bus.we_n.value = we_n
+        self.bus.bank.value = bank
+        self.bus.address.value = address
+        await RisingEdge(self.clock)
+        # Return to deselected idle
+        self.bus.cs_n.value = 1
+        self.bus.ras_n.value = 1
+        self.bus.cas_n.value = 1
+        self.bus.we_n.value = 1
+
+    # ----- Command-interface primitives -----
+
+    async def activate(self, bank: int, row: int) -> None:
+        """ACT bank → row. (ras_n=0, cas_n=1, we_n=1)"""
+        await self._drive_command(ras_n=0, cas_n=1, we_n=1, bank=bank, address=row)
+
+    async def read(self, bank: int, col: int, auto_precharge: bool = False) -> None:
+        """RD bank, col. (ras_n=1, cas_n=0, we_n=1)
+
+        ``auto_precharge`` sets address bit 10 per the JEDEC convention.
+        """
+        addr = col | (1 << 10) if auto_precharge else col
+        await self._drive_command(ras_n=1, cas_n=0, we_n=1, bank=bank, address=addr)
+
+    async def write(self, bank: int, col: int, auto_precharge: bool = False) -> None:
+        """WR bank, col. (ras_n=1, cas_n=0, we_n=0)"""
+        addr = col | (1 << 10) if auto_precharge else col
+        await self._drive_command(ras_n=1, cas_n=0, we_n=0, bank=bank, address=addr)
+
+    async def precharge(self, bank: int = 0, all_banks: bool = False) -> None:
+        """PRE bank (or PREA all-banks). (ras_n=0, cas_n=1, we_n=0)"""
+        addr = (1 << 10) if all_banks else 0
+        await self._drive_command(ras_n=0, cas_n=1, we_n=0, bank=bank, address=addr)
+
+    async def refresh(self) -> None:
+        """REF (all-bank refresh). (ras_n=0, cas_n=0, we_n=1)"""
+        await self._drive_command(ras_n=0, cas_n=0, we_n=1)
+
+    async def nop(self, cycles: int = 1) -> None:
+        """Idle for ``cycles`` clocks.
+
+        Use between primitives to satisfy tRCD / CWL / etc. — the master
+        does not insert spacing automatically (the slave-side DramStateModel
+        flags violations if the caller is too aggressive).
+        """
+        for _ in range(cycles):
+            await RisingEdge(self.clock)
+
+    # ----- Write-data-interface primitive -----
+
+    async def write_data(self, data: int, mask: int = 0) -> None:
+        """Drive one beat of write data on the next clock edge."""
+        self.bus.wrdata.value = data
+        self.bus.wrdata_mask.value = mask
+        self.bus.wrdata_en.value = 1
+        await RisingEdge(self.clock)
+        self.bus.wrdata_en.value = 0
+
+    # ----- Read-data hint -----
+
+    def set_rddata_en(self, value: int = 1) -> None:
+        """Set the rddata_en hint (MC → PHY).
+
+        Stays asserted until the caller flips it back. Doesn't wait —
+        callers usually pair it with ``nop(cycles=CL)`` then assert/
+        deassert around the expected read-data window.
+        """
+        self.bus.rddata_en.value = value

--- a/src/CocoTBFramework/components/dfi/dfi_monitor.py
+++ b/src/CocoTBFramework/components/dfi/dfi_monitor.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""Passive DFI bus monitor (issue #16).
+
+:class:`DFIMonitor` is a cocotb_bus.BusMonitor subclass that samples the
+DFI command, write-data, and read-data sub-interfaces every clock and
+dispatches captured packets to per-sub-interface queues. It can be
+attached to either side of a :file:`tests/sim/rtl/dfi/dfi_shim.sv` —
+the ``side`` argument selects the ``mc_dfi`` vs ``phy_dfi`` signal
+prefix — so two monitor instances (one per side) can verify a packet
+made it across the wire unchanged.
+
+Design notes:
+  - Unlike the single-channel BFMs (APB/GAXI) where one ``_recvQ`` is
+    enough, DFI has three parallel sub-interface timelines that overlap
+    (a write-data beat can land on the same cycle as a new ACT command),
+    so the monitor exposes separate queues: ``command_q``,
+    ``write_data_q``, ``read_data_q``.
+  - Sampling is **falling edge** of ``dfi_clk`` (matching APB / cocotb
+    convention) so values are stable post-rising-edge propagation.
+  - Command capture is gated on ``cs_n == 0`` (CS active-low select).
+    The captured packet's ``cmd`` field is the JEDEC decode of
+    ``(ras_n, cas_n, we_n)`` per DFI v2.1 / JESD79-3F Table 67.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, List, Optional
+
+from cocotb.triggers import FallingEdge
+from cocotb.utils import get_sim_time
+from cocotb_bus.monitors import BusMonitor
+
+from .dfi_packet import DFIControlPacket, DFIReadDataPacket, DFIWriteDataPacket, DRAMCommand
+
+
+# Reverse-lookup table: (ras_n, cas_n, we_n) → DRAMCommand.
+# Matches dfi_packet._DDR3_ENCODING. CS_n is checked separately; this
+# table assumes the chip is already selected.
+_CMD_DECODE = {
+    (0, 1, 1): DRAMCommand.ACT,
+    (1, 0, 1): DRAMCommand.RD,
+    (1, 0, 0): DRAMCommand.WR,
+    (0, 1, 0): DRAMCommand.PRE,
+    (0, 0, 1): DRAMCommand.REF,
+    (0, 0, 0): DRAMCommand.MRS,
+    (1, 1, 1): DRAMCommand.NOP,
+}
+
+
+# Signal sets per sub-interface. Names match the dfi_signals catalog —
+# no `dfi_` prefix here; the prefix comes from the BusMonitor `prefix`
+# constructor argument so we resolve `<prefix>_<signal>` on the DUT.
+_COMMAND_SIGNALS = ("address", "bank", "cas_n", "ras_n", "we_n", "cs_n",
+                    "cke", "odt", "reset_n")
+_WRITE_DATA_SIGNALS = ("wrdata", "wrdata_en", "wrdata_mask")
+_READ_DATA_SIGNALS = ("rddata", "rddata_en", "rddata_valid")
+
+
+def _v(sig) -> int:
+    """Read a cocotb signal as int, returning 0 if unresolvable (X/Z)."""
+    v = sig.value
+    return v.integer if v.is_resolvable else 0
+
+
+class DFIMonitor(BusMonitor):
+    """Per-sub-interface DFI bus monitor.
+
+    Args:
+        entity: The cocotb DUT handle.
+        clock:  The DFI clock signal.
+        side:   ``"mc"`` to attach to the MC-facing port of the shim,
+                ``"phy"`` for the PHY-facing port. Determines the signal
+                prefix (``mc_dfi`` vs ``phy_dfi``).
+        title:  Optional title for log messages.
+    """
+
+    _signals = list(_COMMAND_SIGNALS) + list(_WRITE_DATA_SIGNALS) + list(_READ_DATA_SIGNALS)
+    _optional_signals: List[str] = []
+
+    def __init__(
+        self,
+        entity,
+        clock,
+        side: str = "phy",
+        title: Optional[str] = None,
+        **kwargs,
+    ):
+        if side not in ("mc", "phy"):
+            raise ValueError(f"side must be 'mc' or 'phy', got {side!r}")
+        self.side = side
+        self.title = title or f"DFIMonitor[{side}]"
+
+        prefix = f"{side}_dfi"
+        BusMonitor.__init__(self, entity, prefix, clock, **kwargs)
+        self.clock = clock
+        self.log = self.entity._log
+
+        # Per-sub-interface capture queues. The default _recvQ from
+        # BusMonitor still works (every packet goes there too), but
+        # consumers usually want them split.
+        self.command_q: Deque[DFIControlPacket] = deque()
+        self.write_data_q: Deque[DFIWriteDataPacket] = deque()
+        self.read_data_q: Deque[DFIReadDataPacket] = deque()
+
+        self.command_count = 0
+        self.write_data_count = 0
+        self.read_data_count = 0
+
+    # ----- Decoders -----
+
+    def _decode_command(self) -> DRAMCommand:
+        ras = _v(self.bus.ras_n)
+        cas = _v(self.bus.cas_n)
+        we  = _v(self.bus.we_n)
+        return _CMD_DECODE.get((ras, cas, we), DRAMCommand.NOP)
+
+    # ----- Sampling loop -----
+
+    async def _monitor_recv(self):
+        while True:
+            await FallingEdge(self.clock)
+            ts = get_sim_time("ns")
+
+            # --- Command sub-interface: capture when CS is asserted ---
+            cs_n = _v(self.bus.cs_n)
+            if cs_n == 0:
+                cmd = self._decode_command()
+                if cmd != DRAMCommand.NOP:
+                    pkt = DFIControlPacket(
+                        address=_v(self.bus.address),
+                        cke=_v(self.bus.cke),
+                        cs_n=cs_n,
+                        bank=_v(self.bus.bank),
+                        cas_n=_v(self.bus.cas_n),
+                        ras_n=_v(self.bus.ras_n),
+                        we_n=_v(self.bus.we_n),
+                        odt=_v(self.bus.odt),
+                        reset_n=_v(self.bus.reset_n),
+                        cmd=cmd,
+                        timestamp_ns=ts,
+                    )
+                    self.command_q.append(pkt)
+                    self.command_count += 1
+                    self._recv(pkt)
+
+            # --- Write data sub-interface ---
+            wrdata_en = _v(self.bus.wrdata_en)
+            if wrdata_en:
+                pkt = DFIWriteDataPacket(
+                    wrdata=_v(self.bus.wrdata),
+                    wrdata_en=wrdata_en,
+                    wrdata_mask=_v(self.bus.wrdata_mask),
+                    timestamp_ns=ts,
+                )
+                self.write_data_q.append(pkt)
+                self.write_data_count += 1
+                self._recv(pkt)
+
+            # --- Read data sub-interface ---
+            rddata_valid = _v(self.bus.rddata_valid)
+            if rddata_valid:
+                pkt = DFIReadDataPacket(
+                    rddata=_v(self.bus.rddata),
+                    rddata_valid=rddata_valid,
+                    timestamp_ns=ts,
+                )
+                self.read_data_q.append(pkt)
+                self.read_data_count += 1
+                self._recv(pkt)
+
+    # ----- Convenience helpers -----
+
+    def clear_queues(self) -> None:
+        self.command_q.clear()
+        self.write_data_q.clear()
+        self.read_data_q.clear()
+
+    def __str__(self) -> str:
+        return (
+            f"{self.title}: cmd={self.command_count} "
+            f"wr={self.write_data_count} rd={self.read_data_count}"
+        )

--- a/src/CocoTBFramework/components/dfi/dfi_packet.py
+++ b/src/CocoTBFramework/components/dfi/dfi_packet.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""Packet types for the three MVP DFI sub-interfaces (issue #16).
+
+One packet per cycle of activity on a sub-interface:
+
+- :class:`DFIControlPacket` — one cycle's worth of control-interface
+  signals (address/bank/cmd/cs/cke/odt/reset, gated on memory type)
+- :class:`DFIWriteDataPacket` — one beat of wrdata + wrdata_en + mask
+- :class:`DFIReadDataPacket` — one beat of rddata + rddata_valid (+ dnv
+  for LPDDR2)
+
+Each packet captures the **memory-type-gated** signal set as optional
+fields (default 0 when the signal isn't applicable to the target
+memory). This keeps the packet API uniform — testbenches don't need
+per-version conditional packing.
+
+A separate convenience builder :class:`DFICommand` translates a
+high-level DRAM command (ACT, RD, WR, PRE, REF, NOP) into the right
+combination of RAS/CAS/WE/CS/CKE bits for the target memory type.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .dfi_signals import MemoryType
+
+# ----------------------------------------------------------------------
+# DRAM command encoding (high-level → RAS/CAS/WE/CS bits)
+# ----------------------------------------------------------------------
+
+
+class DRAMCommand(str, Enum):
+    """High-level DRAM command codes. Maps to RAS/CAS/WE/CS bit pattern
+    via :meth:`DFICommand.encode`."""
+
+    NOP = "nop"           # No operation
+    ACT = "activate"      # Activate row
+    RD = "read"           # Read
+    RDA = "read_auto"     # Read with auto-precharge
+    WR = "write"          # Write
+    WRA = "write_auto"    # Write with auto-precharge
+    PRE = "precharge"     # Precharge bank
+    PREA = "precharge_all"  # Precharge all banks
+    REF = "refresh"       # Auto refresh
+    SRE = "self_refresh_entry"
+    SRX = "self_refresh_exit"
+    PDE = "powerdown_entry"
+    PDX = "powerdown_exit"
+    MRS = "mode_register_set"
+    ZQCS = "zq_calibration_short"
+    ZQCL = "zq_calibration_long"
+    DESEL = "deselect"    # CS_n high — no command
+
+
+# Encoding: (cs_n, ras_n, cas_n, we_n) for DDR3 (DDR2/DDR1 mostly same).
+# 0 = asserted (active-low), 1 = deasserted.
+# Per JEDEC JESD79-3F Table 67. LPDDR2 uses a totally different CA bus
+# encoding and doesn't use these signals — call ``encode_lpddr2_ca``
+# instead.
+_DDR3_ENCODING = {
+    DRAMCommand.DESEL: (1, 1, 1, 1),
+    DRAMCommand.NOP:   (0, 1, 1, 1),
+    DRAMCommand.ACT:   (0, 0, 1, 1),
+    DRAMCommand.RD:    (0, 1, 0, 1),
+    DRAMCommand.RDA:   (0, 1, 0, 1),  # auto-precharge encoded in addr[10]
+    DRAMCommand.WR:    (0, 1, 0, 0),
+    DRAMCommand.WRA:   (0, 1, 0, 0),  # auto-precharge encoded in addr[10]
+    DRAMCommand.PRE:   (0, 0, 1, 0),
+    DRAMCommand.PREA:  (0, 0, 1, 0),  # all-banks encoded in addr[10]
+    DRAMCommand.REF:   (0, 0, 0, 1),
+    DRAMCommand.MRS:   (0, 0, 0, 0),
+    DRAMCommand.ZQCS:  (0, 1, 1, 0),  # JESD79-3F Table 67, addr[10]=0
+    DRAMCommand.ZQCL:  (0, 1, 1, 0),  # JESD79-3F Table 67, addr[10]=1
+}
+
+
+# ----------------------------------------------------------------------
+# DFIControlPacket — one cycle of control-interface signals
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class DFIControlPacket:
+    """One cycle's worth of DFI control-interface signal values.
+
+    Every field corresponds to a signal in DFI v2.1 Table 2. Fields
+    that don't apply to a given memory type stay at their defaults
+    (typically 0 or 1 to match the deasserted-idle state per spec) and
+    the BFM simply doesn't drive the corresponding signal if it wasn't
+    instantiated.
+    """
+
+    # Universal (all memory types)
+    address: int = 0
+    cke: int = 0
+    cs_n: int = 1   # deasserted (idle)
+
+    # DDR1/LPDDR1/DDR2/DDR3 (LPDDR2 holds idle)
+    bank: int = 0
+    cas_n: int = 1
+    ras_n: int = 1
+    we_n: int = 1
+
+    # DDR2/DDR3 only
+    odt: int = 0
+
+    # DDR3 only
+    reset_n: int = 1   # deasserted (not in reset)
+
+    @classmethod
+    def from_command(
+        cls,
+        cmd: DRAMCommand,
+        *,
+        memory_type: MemoryType,
+        address: int = 0,
+        bank: int = 0,
+        cs_n: int = 0,    # asserted to actually issue the command
+        cke: int = 1,     # clock-enabled
+        odt: int = 0,
+        auto_precharge: bool = False,
+        all_banks: bool = False,
+    ) -> "DFIControlPacket":
+        """Build a control packet for a high-level DRAM command.
+
+        Handles the (cs_n, ras_n, cas_n, we_n) encoding for the target
+        memory and the addr[10] usage for auto-precharge / all-banks
+        variants.
+        """
+        if memory_type == MemoryType.LPDDR2:
+            raise NotImplementedError(
+                "LPDDR2 uses the dfi_address bus as a 20-bit CA encoding (Table 1); "
+                "build the address word directly and pass it as address=."
+            )
+
+        cs_bit, ras_bit, cas_bit, we_bit = _DDR3_ENCODING[cmd]
+        # The cs_n the user passed is the chip we're targeting; combine
+        # with the spec's cs_n encoding (0 for almost everything except
+        # DESEL/NOP-style idle).
+        effective_cs = cs_n if cs_bit == 0 else 1
+
+        effective_addr = address
+        if auto_precharge and cmd in (DRAMCommand.RD, DRAMCommand.RDA,
+                                       DRAMCommand.WR, DRAMCommand.WRA):
+            effective_addr |= (1 << 10)
+        if all_banks and cmd == DRAMCommand.PREA:
+            effective_addr |= (1 << 10)
+
+        return cls(
+            address=effective_addr,
+            bank=bank,
+            cke=cke,
+            cs_n=effective_cs,
+            ras_n=ras_bit,
+            cas_n=cas_bit,
+            we_n=we_bit,
+            odt=odt,
+        )
+
+
+# ----------------------------------------------------------------------
+# DFIWriteDataPacket — one beat of write data
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class DFIWriteDataPacket:
+    """One beat of the DFI write-data interface."""
+
+    wrdata: int = 0
+    wrdata_en: int = 0    # bit per data slice; asserted during valid beats
+    wrdata_mask: int = 0  # bit per 8 wrdata bits; 1=mask (don't write)
+
+
+# ----------------------------------------------------------------------
+# DFIReadDataPacket — one beat of read data
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class DFIReadDataPacket:
+    """One beat of the DFI read-data interface."""
+
+    rddata: int = 0
+    rddata_valid: int = 0  # bit per slice; asserted during valid beats
+    rddata_dnv: int = 0    # LPDDR2 only: data-not-valid byte mask

--- a/src/CocoTBFramework/components/dfi/dfi_packet.py
+++ b/src/CocoTBFramework/components/dfi/dfi_packet.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
 from .dfi_signals import MemoryType
 
@@ -111,6 +112,10 @@ class DFIControlPacket:
     # DDR3 only
     reset_n: int = 1   # deasserted (not in reset)
 
+    # Capture-side metadata. Populated by DFIMonitor; ignored by drivers.
+    cmd: Optional["DRAMCommand"] = None
+    timestamp_ns: float = 0.0
+
     @classmethod
     def from_command(
         cls,
@@ -175,6 +180,9 @@ class DFIWriteDataPacket:
     wrdata_en: int = 0    # bit per data slice; asserted during valid beats
     wrdata_mask: int = 0  # bit per 8 wrdata bits; 1=mask (don't write)
 
+    # Capture-side metadata. Populated by DFIMonitor; ignored by drivers.
+    timestamp_ns: float = 0.0
+
 
 # ----------------------------------------------------------------------
 # DFIReadDataPacket — one beat of read data
@@ -188,3 +196,6 @@ class DFIReadDataPacket:
     rddata: int = 0
     rddata_valid: int = 0  # bit per slice; asserted during valid beats
     rddata_dnv: int = 0    # LPDDR2 only: data-not-valid byte mask
+
+    # Capture-side metadata. Populated by DFIMonitor; ignored by drivers.
+    timestamp_ns: float = 0.0

--- a/src/CocoTBFramework/components/dfi/dfi_signals.py
+++ b/src/CocoTBFramework/components/dfi/dfi_signals.py
@@ -1,0 +1,430 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""DFI signal envelope by version and memory type (issue #16).
+
+The DDR PHY Interface specification defines a different signal set
+depending on:
+
+1. The DFI **version** (2.1, 3.1, 4.0, 5.2, 6.0). Each new revision is
+   strictly **additive** — later versions add signals, they don't remove
+   them. A small handful of signals have semantic shifts across versions
+   (handled in the BFM, not here).
+
+2. The **memory type** the system targets. ``dfi_reset_n`` exists only for
+   DDR3+; ``dfi_odt`` only for DDR2/DDR3; ``dfi_rddata_dnv`` only for
+   LPDDR2; etc.
+
+3. The **sub-interface profile** the user opts into. The framework
+   supports six sub-interfaces (control, write_data, read_data, update,
+   status, training) and the MVP wires up the first three.
+
+This module encodes that envelope as data so the BFM constructor can
+build a per-instance signal list without scattered ``if version >=``
+checks in the driver code.
+
+Source: DFI v2.1 spec (Denali Software, Jan 2009, cleartext), Tables
+2-11 (pages 9-22). The v3-v6 entries below are populated as the
+corresponding spec PDFs become decryptable; today they fall back to
+the v2.1 envelope, which is a strict subset.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import FrozenSet, List, Optional, Tuple
+
+# ----------------------------------------------------------------------
+# Enums
+# ----------------------------------------------------------------------
+
+
+class DFIVersion(str, Enum):
+    """Supported DFI specification revisions."""
+
+    V2_1 = "2.1"
+    V3_1 = "3.1"
+    V4_0 = "4.0"
+    V5_2 = "5.2"
+    V6_0 = "6.0"
+
+
+class MemoryType(str, Enum):
+    """DRAM memory technologies the DFI can target."""
+
+    DDR1 = "ddr1"
+    DDR2 = "ddr2"
+    DDR3 = "ddr3"
+    DDR4 = "ddr4"
+    DDR5 = "ddr5"
+    LPDDR1 = "lpddr1"
+    LPDDR2 = "lpddr2"
+    LPDDR3 = "lpddr3"
+    LPDDR4 = "lpddr4"
+    LPDDR5 = "lpddr5"
+
+
+class SubInterface(str, Enum):
+    """The six DFI sub-interfaces. MVP wires up the first three."""
+
+    CONTROL = "control"
+    WRITE_DATA = "write_data"
+    READ_DATA = "read_data"
+    UPDATE = "update"
+    STATUS = "status"
+    TRAINING = "training"
+
+
+class SignalDirection(str, Enum):
+    """Direction of a DFI signal from the MC's point of view."""
+
+    MC_TO_PHY = "mc_to_phy"
+    PHY_TO_MC = "phy_to_mc"
+
+
+# What each (version, memory_type) combination supports. Used only for
+# friendly error messages; the actual gating logic lives in the
+# applies_to_memory predicate on each SignalSpec.
+MVP_VERSIONS: FrozenSet[DFIVersion] = frozenset({DFIVersion.V2_1})
+MVP_MEMORY_TYPES: FrozenSet[MemoryType] = frozenset({
+    MemoryType.DDR1,
+    MemoryType.DDR2,
+    MemoryType.DDR3,
+    MemoryType.LPDDR1,
+    MemoryType.LPDDR2,
+})
+MVP_SUB_INTERFACES: FrozenSet[SubInterface] = frozenset({
+    SubInterface.CONTROL,
+    SubInterface.WRITE_DATA,
+    SubInterface.READ_DATA,
+})
+
+
+# ----------------------------------------------------------------------
+# Signal specification
+# ----------------------------------------------------------------------
+
+
+# Width keywords resolved at BFM construction time from the user's
+# width parameters. The strings here are sentinels; the resolver maps
+# them to concrete ints.
+WIDTH_ADDR = "addr_width"
+WIDTH_BANK = "bank_width"
+WIDTH_CS = "cs_width"
+WIDTH_CTRL = "ctrl_width"
+WIDTH_DATA = "data_width"
+WIDTH_DATA_EN = "data_enable_width"
+WIDTH_RD_VALID = "rd_valid_width"
+WIDTH_DATA_DIV8 = "data_width_div_8"  # for masks / dnv
+WIDTH_ONE_BIT = "one_bit"
+WIDTH_TWO_BITS = "two_bits"
+
+
+@dataclass(frozen=True)
+class SignalSpec:
+    """One DFI signal's portability profile.
+
+    ``name`` is without the ``dfi_`` prefix — the BFM joins them.
+    ``width_key`` names a width category that gets resolved against
+    the constructor's per-instance width arguments at BFM init time.
+    ``min_version`` is the earliest DFI revision that introduced the
+    signal. ``memory_types`` is the set of memory technologies where
+    this signal is meaningful (an empty frozenset means "all").
+    """
+
+    name: str
+    direction: SignalDirection
+    width_key: str
+    sub_interface: SubInterface
+    min_version: DFIVersion
+    memory_types: FrozenSet[MemoryType]
+    description: str
+
+    def applies(self, version: DFIVersion, memory_type: MemoryType) -> bool:
+        """Should this signal be present for the given (version, memory)?"""
+        if _version_rank(version) < _version_rank(self.min_version):
+            return False
+        if self.memory_types and memory_type not in self.memory_types:
+            return False
+        return True
+
+
+def _version_rank(v: DFIVersion) -> int:
+    """Ordering for ``min_version`` comparisons."""
+    return {
+        DFIVersion.V2_1: 21,
+        DFIVersion.V3_1: 31,
+        DFIVersion.V4_0: 40,
+        DFIVersion.V5_2: 52,
+        DFIVersion.V6_0: 60,
+    }[v]
+
+
+# ----------------------------------------------------------------------
+# v2.1 signal catalog (from Tables 2, 4, 6 — pages 9-14 of the spec)
+# ----------------------------------------------------------------------
+
+# Convenience aliases for memory-type frozensets used below.
+_ALL: FrozenSet[MemoryType] = frozenset()  # empty = applies to all memory types
+_DDR1_LPDDR1_DDR2_DDR3: FrozenSet[MemoryType] = frozenset({
+    MemoryType.DDR1, MemoryType.LPDDR1, MemoryType.DDR2, MemoryType.DDR3,
+})
+_DDR2_DDR3: FrozenSet[MemoryType] = frozenset({MemoryType.DDR2, MemoryType.DDR3})
+_DDR3_ONLY: FrozenSet[MemoryType] = frozenset({MemoryType.DDR3})
+_LPDDR2_ONLY: FrozenSet[MemoryType] = frozenset({MemoryType.LPDDR2})
+
+
+# Control Interface — DFI v2.1 Table 2 (page 9-10)
+_CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
+    SignalSpec(
+        name="address",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_ADDR,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="DFI address bus (LPDDR2: 20-bit CA bus via Table 1)",
+    ),
+    SignalSpec(
+        name="bank",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_BANK,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_DDR1_LPDDR1_DDR2_DDR3,
+        description="DFI bank bus; LPDDR2 holds idle",
+    ),
+    SignalSpec(
+        name="cas_n",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CTRL,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_DDR1_LPDDR1_DDR2_DDR3,
+        description="DFI column address strobe; LPDDR2 holds idle",
+    ),
+    SignalSpec(
+        name="cke",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CS,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="DFI clock enable (reset polarity is memory-defined)",
+    ),
+    SignalSpec(
+        name="cs_n",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CS,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="DFI chip select",
+    ),
+    SignalSpec(
+        name="odt",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CS,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_DDR2_DDR3,
+        description="DFI on-die termination control (DDR2/DDR3 only)",
+    ),
+    SignalSpec(
+        name="ras_n",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CTRL,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_DDR1_LPDDR1_DDR2_DDR3,
+        description="DFI row address strobe; LPDDR2 holds idle",
+    ),
+    SignalSpec(
+        name="reset_n",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CS,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_DDR3_ONLY,
+        description="DFI reset (DDR3 only)",
+    ),
+    SignalSpec(
+        name="we_n",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_CTRL,
+        sub_interface=SubInterface.CONTROL,
+        min_version=DFIVersion.V2_1,
+        memory_types=_DDR1_LPDDR1_DDR2_DDR3,
+        description="DFI write enable; LPDDR2 holds idle",
+    ),
+)
+
+
+# Write Data Interface — DFI v2.1 Table 4 (page 11-12)
+_WRITE_DATA_SIGNALS: Tuple[SignalSpec, ...] = (
+    SignalSpec(
+        name="wrdata",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_DATA,
+        sub_interface=SubInterface.WRITE_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="Write data; begins 1 cycle after wrdata_en assertion",
+    ),
+    SignalSpec(
+        name="wrdata_en",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_DATA_EN,
+        sub_interface=SubInterface.WRITE_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="Write data enable; asserted t_phy_wrlat cycles after write cmd",
+    ),
+    SignalSpec(
+        name="wrdata_mask",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_DATA_DIV8,
+        sub_interface=SubInterface.WRITE_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="Byte mask for wrdata; 1 bit per 8 wrdata bits",
+    ),
+)
+
+
+# Read Data Interface — DFI v2.1 Table 6 (page 14)
+_READ_DATA_SIGNALS: Tuple[SignalSpec, ...] = (
+    SignalSpec(
+        name="rddata",
+        direction=SignalDirection.PHY_TO_MC,
+        width_key=WIDTH_DATA,
+        sub_interface=SubInterface.READ_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="Read data; valid when rddata_valid asserts",
+    ),
+    SignalSpec(
+        name="rddata_en",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key=WIDTH_DATA_EN,
+        sub_interface=SubInterface.READ_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="Read data enable; asserted t_rddata_en after read cmd",
+    ),
+    SignalSpec(
+        name="rddata_valid",
+        direction=SignalDirection.PHY_TO_MC,
+        width_key=WIDTH_RD_VALID,
+        sub_interface=SubInterface.READ_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_ALL,
+        description="Read data valid; asserted with rddata, max t_phy_rdlat after rddata_en",
+    ),
+    SignalSpec(
+        name="rddata_dnv",
+        direction=SignalDirection.PHY_TO_MC,
+        width_key=WIDTH_DATA_DIV8,
+        sub_interface=SubInterface.READ_DATA,
+        min_version=DFIVersion.V2_1,
+        memory_types=_LPDDR2_ONLY,
+        description="Data-not-valid (LPDDR2 only); byte-granular",
+    ),
+)
+
+
+# All signals across the catalog. Phase 2 adds update/status/training.
+_ALL_SIGNALS: Tuple[SignalSpec, ...] = (
+    _CONTROL_SIGNALS + _WRITE_DATA_SIGNALS + _READ_DATA_SIGNALS
+)
+
+
+# ----------------------------------------------------------------------
+# Public API: envelope resolution
+# ----------------------------------------------------------------------
+
+
+def signals_for(
+    version: DFIVersion,
+    memory_type: MemoryType,
+    sub_interfaces: Optional[FrozenSet[SubInterface]] = None,
+) -> Tuple[SignalSpec, ...]:
+    """Return the signal specs that apply for the given configuration.
+
+    ``sub_interfaces`` defaults to the MVP set (control + write_data +
+    read_data). Pass an explicit set to opt into more (or fewer) channels.
+    """
+    if sub_interfaces is None:
+        sub_interfaces = MVP_SUB_INTERFACES
+    return tuple(
+        s for s in _ALL_SIGNALS
+        if s.sub_interface in sub_interfaces and s.applies(version, memory_type)
+    )
+
+
+def required_signal_names(
+    version: DFIVersion,
+    memory_type: MemoryType,
+    sub_interfaces: Optional[FrozenSet[SubInterface]] = None,
+    prefix: str = "dfi",
+) -> List[str]:
+    """Return the **always-present** signal names for ``cocotb_bus.BusDriver``
+    / ``BusMonitor`` ``_signals`` lists. Names include the ``<prefix>_``
+    prefix so they match the DUT port names.
+
+    Universal signals (memory_types is empty / all types) go here.
+    """
+    return [
+        f"{prefix}_{s.name}"
+        for s in signals_for(version, memory_type, sub_interfaces)
+        if not s.memory_types  # universal
+    ]
+
+
+def optional_signal_names(
+    version: DFIVersion,
+    memory_type: MemoryType,
+    sub_interfaces: Optional[FrozenSet[SubInterface]] = None,
+    prefix: str = "dfi",
+) -> List[str]:
+    """Return the **conditionally-present** signal names.
+
+    Signals gated on memory_type (odt, reset_n, dnv, etc.) go here so
+    ``cocotb_bus`` doesn't error when the DUT lacks them.
+    """
+    return [
+        f"{prefix}_{s.name}"
+        for s in signals_for(version, memory_type, sub_interfaces)
+        if s.memory_types  # memory-type gated
+    ]
+
+
+def validate_configuration(
+    version: DFIVersion,
+    memory_type: MemoryType,
+    sub_interfaces: FrozenSet[SubInterface],
+) -> None:
+    """Raise ``ValueError`` if the requested combination is outside MVP.
+
+    Phase 2 will widen MVP_VERSIONS, MVP_MEMORY_TYPES, and
+    MVP_SUB_INTERFACES; this function is the single chokepoint.
+    """
+    if version not in MVP_VERSIONS:
+        raise ValueError(
+            f"DFI BFM MVP only supports {sorted(v.value for v in MVP_VERSIONS)}; "
+            f"got {version.value}. Phase 2 will add v3.1/v4.0/v5.2/v6.0 envelopes."
+        )
+    if memory_type not in MVP_MEMORY_TYPES:
+        raise ValueError(
+            f"DFI BFM MVP only supports memory types "
+            f"{sorted(m.value for m in MVP_MEMORY_TYPES)}; got {memory_type.value}. "
+            f"Phase 2 will add DDR4/DDR5/LPDDR3/LPDDR4/LPDDR5."
+        )
+    unsupported = sub_interfaces - MVP_SUB_INTERFACES
+    if unsupported:
+        raise ValueError(
+            f"DFI BFM MVP only supports sub-interfaces "
+            f"{sorted(s.value for s in MVP_SUB_INTERFACES)}; "
+            f"got {sorted(s.value for s in unsupported)} which are Phase 2."
+        )

--- a/src/CocoTBFramework/components/dfi/dfi_signals.py
+++ b/src/CocoTBFramework/components/dfi/dfi_signals.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import FrozenSet, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Optional, Tuple
 
 # ----------------------------------------------------------------------
 # Enums
@@ -51,7 +51,13 @@ class DFIVersion(str, Enum):
 
 
 class MemoryType(str, Enum):
-    """DRAM memory technologies the DFI can target."""
+    """DRAM memory technologies the DFI can target.
+
+    v6.0 dropped DDR/2/3/4 and LPDDR/1/2/3/4 support — see
+    :data:`SUPPORTED_MEMORY_BY_VERSION` for the per-version applicable
+    set. The enum carries every memory type the spec has ever covered
+    so test code can still reference them.
+    """
 
     DDR1 = "ddr1"
     DDR2 = "ddr2"
@@ -63,16 +69,51 @@ class MemoryType(str, Enum):
     LPDDR3 = "lpddr3"
     LPDDR4 = "lpddr4"
     LPDDR5 = "lpddr5"
+    LPDDR6 = "lpddr6"     # v6.0+
+    HBM4 = "hbm4"         # v6.0+
 
 
 class SubInterface(str, Enum):
-    """The six DFI sub-interfaces. MVP wires up the first three."""
+    """The DFI sub-interfaces.
 
-    CONTROL = "control"
+    v2.1 had six (the first six below plus TRAINING). v6.0 §3 lists
+    fourteen distinct interface signal groups — TRAINING was folded
+    into the command/read/write sections, and the others were added
+    across v3-v6. MVP wires up COMMAND + WRITE_DATA + READ_DATA;
+    Phase 2/3 add the rest.
+
+    Naming note: v2.1 called this the "Control Interface"; v6.0
+    renamed to "Command Interface" alongside the ``dfi_address`` →
+    ``dfi_cmdaddr`` signal rename. We use the v6.0 name.
+    """
+
+    # v2.1 baseline (plus the v2.1-only TRAINING below)
+    COMMAND = "command"          # was "control" in v2.1
     WRITE_DATA = "write_data"
     READ_DATA = "read_data"
-    UPDATE = "update"
     STATUS = "status"
+    UPDATE = "update"
+
+    # v3.0+
+    DBI = "dbi"                  # Data Bus Inversion
+    ECC = "ecc"
+    LINK_CRC = "link_crc"        # Link DQ CRC
+
+    # v3.1+
+    LOW_POWER = "low_power"      # split from Status
+
+    # v4.0+
+    PHY_MANAGED = "phy_managed"  # added as "PHY Master Interface", renamed v5.2
+
+    # v5.x+
+    WCK_CONTROL = "wck_control"  # DDR5/LPDDR5 WCK
+    MC_TO_PHY_MSG = "mc_to_phy_msg"
+    PHY_ERROR = "phy_error"
+
+    # HBM-era
+    MULTI_CHANNEL = "multi_channel"
+
+    # v2.1 - v5.x only; folded into command/read/write in v6.0
     TRAINING = "training"
 
 
@@ -83,9 +124,42 @@ class SignalDirection(str, Enum):
     PHY_TO_MC = "phy_to_mc"
 
 
-# What each (version, memory_type) combination supports. Used only for
-# friendly error messages; the actual gating logic lives in the
-# applies_to_memory predicate on each SignalSpec.
+# Per-version memory-type support matrix. Source: revision history of
+# each spec. v3.x onward this is mostly additive; v6.0 explicitly
+# **removed** DDR1-4 and LPDDR1-4 support in favor of DDR5 / LPDDR5 /
+# LPDDR6 / HBM4.
+SUPPORTED_MEMORY_BY_VERSION: Dict[DFIVersion, FrozenSet[MemoryType]] = {
+    DFIVersion.V2_1: frozenset({
+        MemoryType.DDR1, MemoryType.DDR2, MemoryType.DDR3,
+        MemoryType.LPDDR1, MemoryType.LPDDR2,
+    }),
+    DFIVersion.V3_1: frozenset({
+        # v3.0 added DDR4; v3.1 added LPDDR3
+        MemoryType.DDR1, MemoryType.DDR2, MemoryType.DDR3, MemoryType.DDR4,
+        MemoryType.LPDDR1, MemoryType.LPDDR2, MemoryType.LPDDR3,
+    }),
+    DFIVersion.V4_0: frozenset({
+        # v4.0 added LPDDR4
+        MemoryType.DDR1, MemoryType.DDR2, MemoryType.DDR3, MemoryType.DDR4,
+        MemoryType.LPDDR1, MemoryType.LPDDR2, MemoryType.LPDDR3, MemoryType.LPDDR4,
+    }),
+    DFIVersion.V5_2: frozenset({
+        # v5.x added DDR5, LPDDR5; legacy still supported
+        MemoryType.DDR1, MemoryType.DDR2, MemoryType.DDR3, MemoryType.DDR4, MemoryType.DDR5,
+        MemoryType.LPDDR1, MemoryType.LPDDR2, MemoryType.LPDDR3,
+        MemoryType.LPDDR4, MemoryType.LPDDR5,
+    }),
+    DFIVersion.V6_0: frozenset({
+        # v6.0 dropped DDR1-4 and LPDDR1-4; added LPDDR6, HBM4
+        MemoryType.DDR5, MemoryType.LPDDR5, MemoryType.LPDDR6, MemoryType.HBM4,
+    }),
+}
+
+
+# What the MVP envelope covers. These shrink the spec's actual support
+# matrix down to what the BFM has signal-table coverage for today.
+# Phase 2 widens MVP_VERSIONS / MVP_MEMORY_TYPES; Phase 3 widens
+# MVP_SUB_INTERFACES (and possibly MVP_MEMORY_TYPES for HBM4/LPDDR6).
 MVP_VERSIONS: FrozenSet[DFIVersion] = frozenset({DFIVersion.V2_1})
 MVP_MEMORY_TYPES: FrozenSet[MemoryType] = frozenset({
     MemoryType.DDR1,
@@ -95,7 +169,7 @@ MVP_MEMORY_TYPES: FrozenSet[MemoryType] = frozenset({
     MemoryType.LPDDR2,
 })
 MVP_SUB_INTERFACES: FrozenSet[SubInterface] = frozenset({
-    SubInterface.CONTROL,
+    SubInterface.COMMAND,
     SubInterface.WRITE_DATA,
     SubInterface.READ_DATA,
 })
@@ -129,8 +203,16 @@ class SignalSpec:
     ``width_key`` names a width category that gets resolved against
     the constructor's per-instance width arguments at BFM init time.
     ``min_version`` is the earliest DFI revision that introduced the
-    signal. ``memory_types`` is the set of memory technologies where
-    this signal is meaningful (an empty frozenset means "all").
+    signal. ``max_version`` (optional) is the last revision in which
+    it appeared — set when a signal gets removed or renamed; leave as
+    ``None`` if it's still in the current spec. ``memory_types`` is the
+    set of memory technologies where this signal is meaningful (an empty
+    frozenset means "all").
+
+    Renames across versions (e.g. ``dfi_address`` → ``dfi_cmdaddr`` at
+    v6.0) are encoded as two SignalSpec entries: the old name with
+    ``max_version`` set, and the new name with ``min_version`` set to
+    the version that introduced the rename.
     """
 
     name: str
@@ -140,10 +222,13 @@ class SignalSpec:
     min_version: DFIVersion
     memory_types: FrozenSet[MemoryType]
     description: str
+    max_version: Optional[DFIVersion] = None
 
     def applies(self, version: DFIVersion, memory_type: MemoryType) -> bool:
         """Should this signal be present for the given (version, memory)?"""
         if _version_rank(version) < _version_rank(self.min_version):
+            return False
+        if self.max_version is not None and _version_rank(version) > _version_rank(self.max_version):
             return False
         if self.memory_types and memory_type not in self.memory_types:
             return False
@@ -175,13 +260,16 @@ _DDR3_ONLY: FrozenSet[MemoryType] = frozenset({MemoryType.DDR3})
 _LPDDR2_ONLY: FrozenSet[MemoryType] = frozenset({MemoryType.LPDDR2})
 
 
-# Control Interface — DFI v2.1 Table 2 (page 9-10)
-_CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
+# Command (a.k.a. "Control") Interface — DFI v2.1 Table 2 (pages 9-10).
+# The "Command Interface" name dates from v6.0; v2.1 called it the
+# "Control Interface" and the bus was named ``dfi_address``. v6.0
+# renamed the bus to ``dfi_cmdaddr``; same logical role.
+_COMMAND_SIGNALS: Tuple[SignalSpec, ...] = (
     SignalSpec(
         name="address",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_ADDR,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_ALL,
         description="DFI address bus (LPDDR2: 20-bit CA bus via Table 1)",
@@ -190,7 +278,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="bank",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_BANK,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_DDR1_LPDDR1_DDR2_DDR3,
         description="DFI bank bus; LPDDR2 holds idle",
@@ -199,7 +287,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="cas_n",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CTRL,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_DDR1_LPDDR1_DDR2_DDR3,
         description="DFI column address strobe; LPDDR2 holds idle",
@@ -208,7 +296,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="cke",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CS,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_ALL,
         description="DFI clock enable (reset polarity is memory-defined)",
@@ -217,7 +305,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="cs_n",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CS,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_ALL,
         description="DFI chip select",
@@ -226,7 +314,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="odt",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CS,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_DDR2_DDR3,
         description="DFI on-die termination control (DDR2/DDR3 only)",
@@ -235,7 +323,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="ras_n",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CTRL,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_DDR1_LPDDR1_DDR2_DDR3,
         description="DFI row address strobe; LPDDR2 holds idle",
@@ -244,7 +332,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="reset_n",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CS,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_DDR3_ONLY,
         description="DFI reset (DDR3 only)",
@@ -253,7 +341,7 @@ _CONTROL_SIGNALS: Tuple[SignalSpec, ...] = (
         name="we_n",
         direction=SignalDirection.MC_TO_PHY,
         width_key=WIDTH_CTRL,
-        sub_interface=SubInterface.CONTROL,
+        sub_interface=SubInterface.COMMAND,
         min_version=DFIVersion.V2_1,
         memory_types=_DDR1_LPDDR1_DDR2_DDR3,
         description="DFI write enable; LPDDR2 holds idle",
@@ -336,7 +424,7 @@ _READ_DATA_SIGNALS: Tuple[SignalSpec, ...] = (
 
 # All signals across the catalog. Phase 2 adds update/status/training.
 _ALL_SIGNALS: Tuple[SignalSpec, ...] = (
-    _CONTROL_SIGNALS + _WRITE_DATA_SIGNALS + _READ_DATA_SIGNALS
+    _COMMAND_SIGNALS + _WRITE_DATA_SIGNALS + _READ_DATA_SIGNALS
 )
 
 
@@ -405,10 +493,16 @@ def validate_configuration(
     memory_type: MemoryType,
     sub_interfaces: FrozenSet[SubInterface],
 ) -> None:
-    """Raise ``ValueError`` if the requested combination is outside MVP.
+    """Raise ``ValueError`` for unsupported configurations.
 
-    Phase 2 will widen MVP_VERSIONS, MVP_MEMORY_TYPES, and
-    MVP_SUB_INTERFACES; this function is the single chokepoint.
+    Validates in this order:
+
+    1. ``version`` is in the MVP set (Phase 2 widens this).
+    2. ``memory_type`` is in the MVP set (Phase 2 widens this).
+    3. ``(version, memory_type)`` is a valid pair per the spec —
+       :data:`SUPPORTED_MEMORY_BY_VERSION` is the canonical source. This
+       catches e.g. ``v6.0`` + ``ddr3`` even after both are added to MVP.
+    4. All requested sub-interfaces are in the MVP set.
     """
     if version not in MVP_VERSIONS:
         raise ValueError(
@@ -419,12 +513,26 @@ def validate_configuration(
         raise ValueError(
             f"DFI BFM MVP only supports memory types "
             f"{sorted(m.value for m in MVP_MEMORY_TYPES)}; got {memory_type.value}. "
-            f"Phase 2 will add DDR4/DDR5/LPDDR3/LPDDR4/LPDDR5."
+            f"Phase 2 will add DDR4/DDR5/LPDDR3/LPDDR4/LPDDR5; Phase 3 adds LPDDR6/HBM4."
+        )
+    supported = SUPPORTED_MEMORY_BY_VERSION[version]
+    if memory_type not in supported:
+        raise ValueError(
+            f"DFI {version.value} does not support memory type {memory_type.value}. "
+            f"Per spec, v{version.value} supports "
+            f"{sorted(m.value for m in supported)}."
         )
     unsupported = sub_interfaces - MVP_SUB_INTERFACES
     if unsupported:
         raise ValueError(
             f"DFI BFM MVP only supports sub-interfaces "
             f"{sorted(s.value for s in MVP_SUB_INTERFACES)}; "
-            f"got {sorted(s.value for s in unsupported)} which are Phase 2."
+            f"got {sorted(s.value for s in unsupported)} which are Phase 2/3."
         )
+
+
+def is_supported_pair(version: DFIVersion, memory_type: MemoryType) -> bool:
+    """Return True if the spec defines support for ``memory_type`` at
+    ``version``. See :data:`SUPPORTED_MEMORY_BY_VERSION`.
+    """
+    return memory_type in SUPPORTED_MEMORY_BY_VERSION.get(version, frozenset())

--- a/src/CocoTBFramework/components/dfi/dfi_slave_phy.py
+++ b/src/CocoTBFramework/components/dfi/dfi_slave_phy.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""PHY-side DFI slave BFM (issue #16).
+
+:class:`DFISlavePHY` is the responder side of a DFI link. It:
+
+  - Captures the MC's command stream off the wire (Slave-via-BusMonitor
+    pattern, see ``docs/components/components_overview.md``).
+  - Maintains a per-bank :class:`DramStateModel` and reports JEDEC
+    sequencing/timing violations as the MC drives commands.
+  - Auto-commits write data: ``CWL`` cycles after a WR command, it
+    captures the ``wrdata`` beat off the wire and writes it through
+    ``AddressMapping`` to the numpy-backed :class:`MemoryModel`.
+  - Queues read requests so any in-flight write commits first, then
+    drives ``rddata`` / ``rddata_valid`` for one cycle when the
+    response is due. (User chose queue-don't-collide semantics over
+    "fire CL cycles later no matter what" — see project_dfi_address_mapping
+    memory note.)
+
+MVP scope: BL=1 conceptually — one DFI beat per WR / RD command. Real
+DDR3 is BL8 minimum, but locking the BL=1 case down first proves the
+address-decode + memory-binding mechanics. Multi-beat bursts are
+Phase 2.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Optional
+
+from cocotb.triggers import FallingEdge
+from cocotb_bus.monitors import BusMonitor
+
+from ..shared.memory_model import MemoryModel
+from .dfi_base import DFIBase
+from .dfi_monitor import _CMD_DECODE, _COMMAND_SIGNALS, _READ_DATA_SIGNALS, _WRITE_DATA_SIGNALS, _v
+from .dfi_packet import DRAMCommand
+
+
+@dataclass
+class _PendingOp:
+    """One pending memory operation, due at ``due_cycle``."""
+    due_cycle: int
+    flat_addr: int
+
+
+class DFISlavePHY(BusMonitor):
+    """PHY-side DFI BFM with DRAM state model + memory backing.
+
+    Args:
+        entity:   The cocotb DUT handle.
+        clock:    The DFI clock signal.
+        base:     The :class:`DFIBase` chassis carrying version, memory
+                  type, timings, and address mapping.
+        memory:   The :class:`MemoryModel` backing this slave.
+        side:     Currently only ``"phy"`` (the PHY drives the slave role).
+        title:    Optional title for log messages.
+    """
+
+    _signals = list(_COMMAND_SIGNALS) + list(_WRITE_DATA_SIGNALS) + list(_READ_DATA_SIGNALS)
+    _optional_signals: list = []
+
+    def __init__(
+        self,
+        entity,
+        clock,
+        base: DFIBase,
+        memory: MemoryModel,
+        side: str = "phy",
+        title: Optional[str] = None,
+        **kwargs,
+    ):
+        if side != "phy":
+            raise ValueError(
+                f"DFISlavePHY drives the PHY side only, got side={side!r}"
+            )
+        self.side = side
+        self.title = title or "DFISlavePHY"
+        self.base = base
+        self.memory = memory
+        self.mapping = base.mapping
+        # MemoryModel is byte-addressed; one DFI beat is data_width / 8 bytes.
+        # The MVP envelope assumes a single beat per command (BL=1 conceptually).
+        self.bytes_per_beat = max(1, memory.bytes_per_line)
+
+        # Independent state model — caller's base might be shared with a
+        # master and we want the slave's view to be fully self-contained.
+        from .dram_state import DramStateModel  # local import to avoid cycle
+        self.dram = DramStateModel(
+            timings=base.timings,
+            num_banks=base.mapping.num_banks,
+        )
+
+        BusMonitor.__init__(self, entity, f"{side}_dfi", clock, **kwargs)
+        self.clock = clock
+        self.log = self.entity._log
+
+        # Pending operation queues. Reads serialize behind writes
+        # already in flight — the user wants queue-don't-collide
+        # semantics so the slave never produces stale data while a
+        # write is still draining.
+        self._pending_reads: Deque[_PendingOp] = deque()
+        self._pending_writes: Deque[_PendingOp] = deque()
+
+        # Statistics
+        self.cmd_counts = {cmd: 0 for cmd in DRAMCommand}
+        self.writes_committed = 0
+        self.reads_served = 0
+
+        # Initialize PHY-driven outputs
+        self.bus.rddata.value = 0
+        self.bus.rddata_valid.value = 0
+
+    # ----- Address helpers -----
+
+    @property
+    def _col_mask(self) -> int:
+        return (1 << self.mapping._widths["col"]) - 1
+
+    def _flat_addr_for(self, bank: int, raw_address: int) -> int:
+        """Build a flat column-unit address from bank + WR/RD address."""
+        open_row = self.dram.banks[bank].row
+        if open_row is None:
+            # Will trip a no_act_before_rd/wr violation in DramStateModel;
+            # use row=0 just to keep the math defined.
+            open_row = 0
+        col = raw_address & self._col_mask
+        return self.mapping.tuple_to_flat(0, bank, open_row, col)
+
+    def _byte_addr(self, flat: int) -> int:
+        return flat * self.bytes_per_beat
+
+    # ----- Command dispatch -----
+
+    def _decode_command(self) -> DRAMCommand:
+        ras = _v(self.bus.ras_n)
+        cas = _v(self.bus.cas_n)
+        we  = _v(self.bus.we_n)
+        return _CMD_DECODE.get((ras, cas, we), DRAMCommand.NOP)
+
+    def _handle_command(self, cmd: DRAMCommand) -> None:
+        bank = _v(self.bus.bank)
+        addr = _v(self.bus.address)
+        cycle = self.dram.cycle  # cycle as the dram model sees it
+        cwl = self.dram.timings.CWL
+        cl  = self.dram.timings.CL
+
+        self.cmd_counts[cmd] = self.cmd_counts.get(cmd, 0) + 1
+
+        if cmd == DRAMCommand.ACT:
+            self.dram.on_activate(bank_idx=bank, row=addr)
+        elif cmd == DRAMCommand.RD:
+            self.dram.on_read(bank_idx=bank)
+            flat = self._flat_addr_for(bank, addr)
+            self._pending_reads.append(_PendingOp(due_cycle=cycle + cl, flat_addr=flat))
+            if addr & (1 << 10):
+                # Auto-precharge after the read
+                self._pending_auto_pre(bank)
+        elif cmd == DRAMCommand.WR:
+            self.dram.on_write(bank_idx=bank)
+            flat = self._flat_addr_for(bank, addr)
+            self._pending_writes.append(_PendingOp(due_cycle=cycle + cwl, flat_addr=flat))
+            if addr & (1 << 10):
+                self._pending_auto_pre(bank)
+        elif cmd == DRAMCommand.PRE:
+            all_banks = bool(addr & (1 << 10))
+            self.dram.on_precharge(bank_idx=bank, all_banks=all_banks)
+        elif cmd == DRAMCommand.REF:
+            self.dram.on_refresh()
+        # MRS / NOP: ignored for MVP (just kept in cmd_counts)
+
+    def _pending_auto_pre(self, bank: int) -> None:
+        # MVP: defer the auto-precharge accounting until the BFM grows a
+        # proper post-data scheduler. For now log it so it's not silently
+        # dropped — full handling lands when multi-beat bursts arrive.
+        self.log.debug(f"{self.title}: auto-precharge requested for bank {bank}")
+
+    # ----- Pending operation servicing -----
+
+    def _serve_writes(self) -> None:
+        """Commit any pending writes whose CWL has elapsed."""
+        cycle = self.dram.cycle
+        while self._pending_writes and self._pending_writes[0].due_cycle <= cycle:
+            op = self._pending_writes.popleft()
+            if _v(self.bus.wrdata_en) == 0:
+                self.log.warning(
+                    f"{self.title}: pending write at flat=0x{op.flat_addr:x} "
+                    f"due cycle {op.due_cycle} but wrdata_en is deasserted — "
+                    "did the MC forget the data beat?"
+                )
+                continue
+            data = _v(self.bus.wrdata)
+            mask = _v(self.bus.wrdata_mask)
+            ba = self.memory.integer_to_bytearray(data, self.bytes_per_beat)
+            # Strobe is 1 per byte unmasked. The DFI mask convention is
+            # 1=*don't* write the byte, hence invert.
+            strobe = (~mask) & ((1 << self.bytes_per_beat) - 1)
+            self.memory.write(self._byte_addr(op.flat_addr), ba, strobe=strobe)
+            self.writes_committed += 1
+
+    def _serve_reads(self) -> None:
+        """Drive rddata + rddata_valid for one cycle when a read is due.
+
+        Reads serialize behind any pending writes — if a write at the
+        same cycle hasn't committed yet, the read holds until the next
+        servicing pass.
+        """
+        cycle = self.dram.cycle
+        # Hold back if a write at <= this cycle is still pending — that
+        # write commits first per the user's queue-don't-collide rule.
+        if self._pending_writes and self._pending_writes[0].due_cycle <= cycle:
+            self.bus.rddata_valid.value = 0
+            return
+
+        if self._pending_reads and self._pending_reads[0].due_cycle <= cycle:
+            op = self._pending_reads.popleft()
+            ba = self.memory.read(self._byte_addr(op.flat_addr), self.bytes_per_beat)
+            self.bus.rddata.value = self.memory.bytearray_to_integer(ba)
+            self.bus.rddata_valid.value = 1
+            self.reads_served += 1
+        else:
+            self.bus.rddata_valid.value = 0
+
+    # ----- Sampling loop -----
+
+    async def _monitor_recv(self):
+        while True:
+            await FallingEdge(self.clock)
+
+            self.dram.tick()
+            self.base.tick()
+
+            if _v(self.bus.cs_n) == 0:
+                cmd = self._decode_command()
+                if cmd != DRAMCommand.NOP:
+                    self._handle_command(cmd)
+
+            # Order matters: commit writes first, then serve reads. The
+            # serve_reads helper double-checks so we never produce stale
+            # data while a same-cycle write is still in flight.
+            self._serve_writes()
+            self._serve_reads()
+
+    # ----- Convenience -----
+
+    def __str__(self) -> str:
+        return (
+            f"{self.title}: writes_committed={self.writes_committed} "
+            f"reads_served={self.reads_served} "
+            f"cmd_counts={ {c.value: n for c, n in self.cmd_counts.items() if n} }"
+        )

--- a/src/CocoTBFramework/components/dfi/dram_state.py
+++ b/src/CocoTBFramework/components/dfi/dram_state.py
@@ -21,11 +21,150 @@ from __future__ import annotations
 
 import logging
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Deque, FrozenSet, List, Optional
+from typing import Deque, Dict, FrozenSet, List, Optional, Tuple
 
 from .jedec_timings import JedecTimings
+
+
+# ----------------------------------------------------------------------
+# Address mapping
+# ----------------------------------------------------------------------
+
+
+# Field names recognized in the mapping string. Order matters: MSB→LSB
+# in the resulting flat index, per the mapping string the user supplies.
+_ADDR_FIELDS = ("rank", "bank", "row", "col")
+
+
+def _is_pow2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def _bit_width(n: int) -> int:
+    """Number of bits needed to address ``n`` distinct values (n=1 → 0)."""
+    if n <= 1:
+        return 0
+    return (n - 1).bit_length()
+
+
+@dataclass(frozen=True)
+class AddressMapping:
+    """Configurable flat ↔ (rank, bank, row, col) decoder.
+
+    Models DRAMsim3's late-binding address decode (configuration.cc
+    SetAddressMapping). The mapping string is a pipe-separated MSB→LSB
+    field order, e.g. ``"row|bank|col"`` for the conventional
+    row-buffer-friendly layout, or ``"row|col|bank"`` to push banks
+    into the LSBs.
+
+    Geometry args set the per-field widths; the mapping just dictates
+    the slice order. All counts must be powers of 2.
+
+    The decoder works in **column units** (not bytes). The caller is
+    responsible for the column-to-byte stride (``col * BL * bus_width/8``)
+    if a byte offset is needed.
+    """
+
+    num_ranks: int
+    num_banks: int
+    num_rows: int
+    num_cols: int
+    mapping: str = "row|bank|col"
+
+    # Computed at __post_init__ — kept private to the frozen dataclass.
+    _widths: Dict[str, int] = field(default_factory=dict, repr=False, compare=False)
+    _shifts: Dict[str, int] = field(default_factory=dict, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        for name, n in (
+            ("num_ranks", self.num_ranks),
+            ("num_banks", self.num_banks),
+            ("num_rows", self.num_rows),
+            ("num_cols", self.num_cols),
+        ):
+            if not _is_pow2(n):
+                raise ValueError(f"{name}={n} must be a power of 2")
+
+        fields = [f.strip() for f in self.mapping.split("|") if f.strip()]
+        for f in fields:
+            if f not in _ADDR_FIELDS:
+                raise ValueError(
+                    f"unknown field {f!r} in mapping {self.mapping!r}; "
+                    f"expected one of {_ADDR_FIELDS}"
+                )
+        if len(set(fields)) != len(fields):
+            raise ValueError(f"duplicate field in mapping {self.mapping!r}")
+
+        # col is always required; bank/row required when their count > 1.
+        if "col" not in fields:
+            raise ValueError(f"mapping {self.mapping!r} missing 'col' field")
+        if self.num_banks > 1 and "bank" not in fields:
+            raise ValueError(f"mapping {self.mapping!r} missing 'bank' field")
+        if self.num_rows > 1 and "row" not in fields:
+            raise ValueError(f"mapping {self.mapping!r} missing 'row' field")
+        if self.num_ranks > 1 and "rank" not in fields:
+            raise ValueError(
+                f"mapping {self.mapping!r} missing 'rank' field "
+                f"(num_ranks={self.num_ranks})"
+            )
+
+        widths = {
+            "rank": _bit_width(self.num_ranks),
+            "bank": _bit_width(self.num_banks),
+            "row": _bit_width(self.num_rows),
+            "col": _bit_width(self.num_cols),
+        }
+        # Walk MSB→LSB to assign shifts: rightmost field has shift 0.
+        shifts: Dict[str, int] = {f: 0 for f in _ADDR_FIELDS}
+        running = 0
+        for f in reversed(fields):
+            shifts[f] = running
+            running += widths[f]
+
+        # Dataclass is frozen → bypass __setattr__ for the cached dicts.
+        object.__setattr__(self, "_widths", widths)
+        object.__setattr__(self, "_shifts", shifts)
+
+    @property
+    def total_size(self) -> int:
+        """Number of distinct flat addresses (column units)."""
+        return self.num_ranks * self.num_banks * self.num_rows * self.num_cols
+
+    def tuple_to_flat(self, rank: int, bank: int, row: int, col: int) -> int:
+        """Pack ``(rank, bank, row, col)`` into a flat index."""
+        for name, val, limit in (
+            ("rank", rank, self.num_ranks),
+            ("bank", bank, self.num_banks),
+            ("row", row, self.num_rows),
+            ("col", col, self.num_cols),
+        ):
+            if not (0 <= val < limit):
+                raise ValueError(
+                    f"{name}={val} out of range [0, {limit})"
+                )
+        return (
+            (rank << self._shifts["rank"])
+            | (bank << self._shifts["bank"])
+            | (row << self._shifts["row"])
+            | (col << self._shifts["col"])
+        )
+
+    def flat_to_tuple(self, flat: int) -> Tuple[int, int, int, int]:
+        """Unpack a flat index to ``(rank, bank, row, col)``."""
+        def _extract(name: str, limit: int) -> int:
+            width = self._widths[name]
+            if width == 0:
+                return 0
+            mask = (1 << width) - 1
+            return (flat >> self._shifts[name]) & mask
+        return (
+            _extract("rank", self.num_ranks),
+            _extract("bank", self.num_banks),
+            _extract("row", self.num_rows),
+            _extract("col", self.num_cols),
+        )
 
 # ----------------------------------------------------------------------
 # Violation policy

--- a/src/CocoTBFramework/components/dfi/dram_state.py
+++ b/src/CocoTBFramework/components/dfi/dram_state.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""Per-bank DRAM state machine + JEDEC timing violation checker (issue #16).
+
+The :class:`DramStateModel` tracks per-bank state (idle / active / etc.)
+and the cycle at which each transition happened. The :class:`DFISlavePHY`
+calls into it for every command the MC issues on the wire; the model
+reports timing violations via :class:`ViolationPolicy` — by default,
+critical JEDEC sequencing rules halt sim, windowed/average rules warn,
+init-sequence specifics are ignored.
+
+Scope for MVP: the "hard" checks below are fully wired (5 bank-state
+transitions + 8 timing parameters). Soft checks (tFAW windowed count,
+tREFI overdue) are stubbed — the reporting path works but the windowing
+state hasn't landed yet. Wire-level read-data and write-data servicing
+lives in :mod:`dfi_slave_phy`, not here.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from typing import Deque, FrozenSet, List, Optional
+
+from .jedec_timings import JedecTimings
+
+# ----------------------------------------------------------------------
+# Violation policy
+# ----------------------------------------------------------------------
+
+
+class ViolationCategory(str, Enum):
+    HARD = "hard"
+    SOFT = "soft"
+    IGNORE = "ignore"
+
+
+# Default category for each named violation (see README.md). Override
+# at construction time via ``ViolationPolicy(hard=..., soft=..., ignore=...)``.
+_DEFAULT_HARD: FrozenSet[str] = frozenset({
+    # Bank-state transitions
+    "no_act_before_rd",
+    "no_act_before_wr",
+    "act_on_active_bank",
+    "ref_with_open_row",
+    "cmd_during_refresh",
+    # Timing parameters
+    "tRCD",
+    "tRP",
+    "tRAS_min",
+    "tRC",
+    "tWR",
+    "tWTR",
+    "tRTP",
+    "tRRD",
+})
+_DEFAULT_SOFT: FrozenSet[str] = frozenset({
+    "tFAW",
+    "tREFI",
+    "tRFC",        # softer because refresh model is approximate
+    "CL_mismatch",
+    "CWL_mismatch",
+})
+_DEFAULT_IGNORE: FrozenSet[str] = frozenset({
+    "init_sequence",
+    "zq_calibration",
+    "voltage_temp",
+})
+
+
+class ViolationPolicy:
+    """Configurable per-violation behavior.
+
+    Defaults follow the split in the issue:
+      - hard:  JEDEC-critical sequencing + per-bank timings → ``assert False``
+      - soft:  windowed/average → log warning, count, continue
+      - ignore: init / calibration / voltage-temp specifics → silent
+
+    Any violation name not in any of the three sets defaults to ``SOFT``
+    so future spec additions don't silently crash an existing simulation.
+    """
+
+    def __init__(
+        self,
+        *,
+        hard: Optional[FrozenSet[str]] = None,
+        soft: Optional[FrozenSet[str]] = None,
+        ignore: Optional[FrozenSet[str]] = None,
+    ):
+        self.hard = hard if hard is not None else _DEFAULT_HARD
+        self.soft = soft if soft is not None else _DEFAULT_SOFT
+        self.ignore = ignore if ignore is not None else _DEFAULT_IGNORE
+        self._soft_counts: dict[str, int] = {}
+
+    def category_of(self, name: str) -> ViolationCategory:
+        if name in self.hard:
+            return ViolationCategory.HARD
+        if name in self.ignore:
+            return ViolationCategory.IGNORE
+        # Default: SOFT (includes anything in self.soft plus unknowns)
+        return ViolationCategory.SOFT
+
+    def report(
+        self,
+        name: str,
+        context: str,
+        log: Optional[logging.Logger] = None,
+    ) -> None:
+        """Report a violation; raise / log per the configured category."""
+        cat = self.category_of(name)
+        if cat == ViolationCategory.IGNORE:
+            return
+        msg = f"DRAM timing violation [{name}]: {context}"
+        if cat == ViolationCategory.HARD:
+            raise AssertionError(msg)
+        # SOFT
+        self._soft_counts[name] = self._soft_counts.get(name, 0) + 1
+        if log is not None:
+            log.warning(msg)
+
+    @property
+    def soft_violation_counts(self) -> dict[str, int]:
+        return dict(self._soft_counts)
+
+
+# ----------------------------------------------------------------------
+# Per-bank state
+# ----------------------------------------------------------------------
+
+
+class BankState(str, Enum):
+    IDLE = "idle"
+    ACTIVE = "active"
+    REFRESHING = "refreshing"
+
+
+@dataclass
+class Bank:
+    state: BankState = BankState.IDLE
+    row: Optional[int] = None
+
+    # Cycle counters for timing checks. -1 means "never happened yet".
+    last_act_cycle: int = -1
+    last_pre_cycle: int = -1
+    last_rd_cycle: int = -1
+    last_wr_cycle: int = -1
+    last_wr_data_cycle: int = -1   # last data beat of the most recent WR burst
+    last_rd_data_cycle: int = -1
+    last_ref_end_cycle: int = -1
+
+
+# ----------------------------------------------------------------------
+# DRAM state model
+# ----------------------------------------------------------------------
+
+
+class DramStateModel:
+    """Per-bank state machine + JEDEC timing-violation checker.
+
+    The :class:`DFISlavePHY` calls into ``on_activate`` / ``on_read`` /
+    ``on_write`` / ``on_precharge`` / ``on_refresh`` every cycle in which
+    those commands appear on the wire. Refresh state is approximate —
+    `cmd_during_refresh` covers the common case but the model doesn't
+    yet track tRFC precisely.
+
+    Cycle accounting: the model keeps its own ``cycle`` counter that the
+    slave advances with ``tick()`` per DFI clock edge. Counters use
+    inclusive comparisons (``elapsed = cycle - last_X``) so the spec's
+    "ACT-to-RD must be at least tRCD cycles" reads naturally as
+    ``elapsed >= tRCD_cycles``.
+    """
+
+    def __init__(
+        self,
+        *,
+        timings: JedecTimings,
+        num_banks: int,
+        policy: Optional[ViolationPolicy] = None,
+        log: Optional[logging.Logger] = None,
+    ):
+        if num_banks <= 0:
+            raise ValueError(f"num_banks must be positive, got {num_banks}")
+        self.timings = timings
+        self.banks: List[Bank] = [Bank() for _ in range(num_banks)]
+        self.policy = policy if policy is not None else ViolationPolicy()
+        self.log = log
+        self.cycle = 0
+
+        # tFAW windowing: ring of the last 4 ACT cycles
+        self._act_history: Deque[int] = deque(maxlen=4)
+
+        # Last issued ACT to any bank — for tRRD
+        self._last_act_any_bank: int = -1
+
+        # Refresh tracking — last broadcast REF cycle and end-of-tRFC
+        self._last_ref_cycle: int = -1
+        self._ref_end_cycle: int = -1
+
+    # ----- Time advance -----
+
+    def tick(self) -> None:
+        """Advance one DFI clock cycle. Call once per rising edge."""
+        self.cycle += 1
+        # Walk banks out of REFRESHING once tRFC elapsed
+        if (
+            self._ref_end_cycle >= 0
+            and self.cycle >= self._ref_end_cycle
+        ):
+            for b in self.banks:
+                if b.state == BankState.REFRESHING:
+                    b.state = BankState.IDLE
+                    b.row = None
+                    b.last_ref_end_cycle = self.cycle
+
+    # ----- Command handlers -----
+
+    def on_activate(self, bank_idx: int, row: int) -> None:
+        """Process an ACT command."""
+        self._check_not_refreshing("act")
+        b = self._bank(bank_idx)
+        if b.state == BankState.ACTIVE:
+            self.policy.report(
+                "act_on_active_bank",
+                f"bank={bank_idx} already ACTIVE with row=0x{b.row:x}, "
+                f"got new ACT row=0x{row:x} @ cycle {self.cycle}",
+                self.log,
+            )
+            return
+        # tRP: must wait after last PRE before ACT on same bank
+        if b.last_pre_cycle >= 0:
+            elapsed = self.cycle - b.last_pre_cycle
+            if elapsed < self.timings.tRP_cycles:
+                self.policy.report(
+                    "tRP",
+                    f"bank={bank_idx} ACT only {elapsed} cycles after PRE "
+                    f"(needs {self.timings.tRP_cycles})",
+                    self.log,
+                )
+        # tRC: ACT-to-ACT same bank
+        if b.last_act_cycle >= 0:
+            elapsed = self.cycle - b.last_act_cycle
+            if elapsed < self.timings.tRC_cycles:
+                self.policy.report(
+                    "tRC",
+                    f"bank={bank_idx} ACT-to-ACT only {elapsed} cycles "
+                    f"(needs {self.timings.tRC_cycles})",
+                    self.log,
+                )
+        # tRRD: ACT-to-ACT any-bank
+        if self._last_act_any_bank >= 0:
+            elapsed = self.cycle - self._last_act_any_bank
+            if elapsed < self.timings.tRRD_cycles:
+                self.policy.report(
+                    "tRRD",
+                    f"ACT bank={bank_idx} only {elapsed} cycles after "
+                    f"last ACT (needs {self.timings.tRRD_cycles})",
+                    self.log,
+                )
+        # tFAW: 4 ACTs must fit in tFAW cycles
+        if len(self._act_history) == 4:
+            window = self.cycle - self._act_history[0]
+            if window < self.timings.tFAW_cycles:
+                self.policy.report(
+                    "tFAW",
+                    f"5th ACT within {window} cycle window "
+                    f"(tFAW={self.timings.tFAW_cycles})",
+                    self.log,
+                )
+
+        b.state = BankState.ACTIVE
+        b.row = row
+        b.last_act_cycle = self.cycle
+        self._last_act_any_bank = self.cycle
+        self._act_history.append(self.cycle)
+
+    def on_read(self, bank_idx: int) -> None:
+        """Process a RD command."""
+        self._check_not_refreshing("rd")
+        b = self._bank(bank_idx)
+        if b.state != BankState.ACTIVE:
+            self.policy.report(
+                "no_act_before_rd",
+                f"RD bank={bank_idx} but state={b.state.value} @ cycle {self.cycle}",
+                self.log,
+            )
+        elif b.last_act_cycle >= 0:
+            elapsed = self.cycle - b.last_act_cycle
+            if elapsed < self.timings.tRCD_cycles:
+                self.policy.report(
+                    "tRCD",
+                    f"RD bank={bank_idx} only {elapsed} cycles after ACT "
+                    f"(needs {self.timings.tRCD_cycles})",
+                    self.log,
+                )
+        # tWTR: WR → RD same bank
+        if b.last_wr_data_cycle >= 0:
+            elapsed = self.cycle - b.last_wr_data_cycle
+            if elapsed < self.timings.tWTR_cycles:
+                self.policy.report(
+                    "tWTR",
+                    f"RD bank={bank_idx} only {elapsed} cycles after last "
+                    f"WR data beat (needs {self.timings.tWTR_cycles})",
+                    self.log,
+                )
+        b.last_rd_cycle = self.cycle
+        # Read data lands CL cycles later (BL beats total)
+        b.last_rd_data_cycle = self.cycle + self.timings.CL + self.timings.BL - 1
+
+    def on_write(self, bank_idx: int) -> None:
+        """Process a WR command."""
+        self._check_not_refreshing("wr")
+        b = self._bank(bank_idx)
+        if b.state != BankState.ACTIVE:
+            self.policy.report(
+                "no_act_before_wr",
+                f"WR bank={bank_idx} but state={b.state.value} @ cycle {self.cycle}",
+                self.log,
+            )
+        elif b.last_act_cycle >= 0:
+            elapsed = self.cycle - b.last_act_cycle
+            if elapsed < self.timings.tRCD_cycles:
+                self.policy.report(
+                    "tRCD",
+                    f"WR bank={bank_idx} only {elapsed} cycles after ACT "
+                    f"(needs {self.timings.tRCD_cycles})",
+                    self.log,
+                )
+        b.last_wr_cycle = self.cycle
+        # Write data lands CWL cycles later (BL beats total)
+        b.last_wr_data_cycle = self.cycle + self.timings.CWL + self.timings.BL - 1
+
+    def on_precharge(self, bank_idx: int, all_banks: bool = False) -> None:
+        """Process a PRE command."""
+        self._check_not_refreshing("pre")
+        targets = self.banks if all_banks else [self.banks[bank_idx]]
+        for i, b in enumerate(targets):
+            real_idx = i if all_banks else bank_idx
+            # tRAS_min: ACT-to-PRE same bank
+            if b.last_act_cycle >= 0:
+                elapsed = self.cycle - b.last_act_cycle
+                if elapsed < self.timings.tRAS_min_cycles:
+                    self.policy.report(
+                        "tRAS_min",
+                        f"PRE bank={real_idx} only {elapsed} cycles after ACT "
+                        f"(needs tRAS_min={self.timings.tRAS_min_cycles})",
+                        self.log,
+                    )
+            # tRTP: RD-to-PRE same bank
+            if b.last_rd_cycle >= 0:
+                elapsed = self.cycle - b.last_rd_cycle
+                if elapsed < self.timings.tRTP_cycles:
+                    self.policy.report(
+                        "tRTP",
+                        f"PRE bank={real_idx} only {elapsed} cycles after RD "
+                        f"(needs tRTP={self.timings.tRTP_cycles})",
+                        self.log,
+                    )
+            # tWR: end of WR burst to PRE
+            if b.last_wr_data_cycle >= 0:
+                elapsed = self.cycle - b.last_wr_data_cycle
+                if elapsed < self.timings.tWR_cycles:
+                    self.policy.report(
+                        "tWR",
+                        f"PRE bank={real_idx} only {elapsed} cycles after "
+                        f"last WR data beat (needs tWR={self.timings.tWR_cycles})",
+                        self.log,
+                    )
+            b.state = BankState.IDLE
+            b.row = None
+            b.last_pre_cycle = self.cycle
+
+    def on_refresh(self) -> None:
+        """Process a REF (all-bank refresh) command."""
+        # All banks must be precharged before REF.
+        for i, b in enumerate(self.banks):
+            if b.state == BankState.ACTIVE:
+                self.policy.report(
+                    "ref_with_open_row",
+                    f"REF issued but bank {i} is ACTIVE (row=0x{b.row:x}) "
+                    f"@ cycle {self.cycle}",
+                    self.log,
+                )
+        for b in self.banks:
+            b.state = BankState.REFRESHING
+            b.row = None
+        self._last_ref_cycle = self.cycle
+        self._ref_end_cycle = self.cycle + self.timings.tRFC_cycles
+
+    # ----- Helpers -----
+
+    def _bank(self, idx: int) -> Bank:
+        if not (0 <= idx < len(self.banks)):
+            raise IndexError(f"bank_idx {idx} out of range [0, {len(self.banks)})")
+        return self.banks[idx]
+
+    def _check_not_refreshing(self, cmd: str) -> None:
+        if any(b.state == BankState.REFRESHING for b in self.banks):
+            self.policy.report(
+                "cmd_during_refresh",
+                f"{cmd.upper()} command issued while refresh in progress "
+                f"(REF started cycle {self._last_ref_cycle}, "
+                f"ends cycle {self._ref_end_cycle})",
+                self.log,
+            )

--- a/src/CocoTBFramework/components/dfi/jedec/README.md
+++ b/src/CocoTBFramework/components/dfi/jedec/README.md
@@ -1,0 +1,88 @@
+# JEDEC timing tables (provisional format)
+
+CSV files in this directory feed the `DFISlavePHY`'s DRAM state model.
+Each file pins one (memory_type, speed_grade) combination's relevant
+JEDEC timings; the slave's runtime checker enforces them against the
+sequence of commands it sees on the wire.
+
+## Pre-alpha note
+
+The format below is a first stab — pretty much guaranteed to be wrong
+once we hit something we hadn't anticipated. Treat it as the v0 schema.
+Iterate freely.
+
+## File naming
+
+```
+<memory_type>-<speed_grade>.csv
+```
+
+Examples: `ddr3-1600.csv`, `ddr3-1866.csv`, `ddr4-2400.csv` (Phase 2),
+`ddr5-6400.csv` (Phase 3).
+
+## File format
+
+UTF-8 CSV, four columns:
+
+```csv
+# Comments allowed on lines starting with '#'.
+parameter, unit, value, description
+tCK,        ns,  1.25,  Clock period
+tRCD,       ns,  13.75, ACT → RD/WR same bank
+tRP,        ns,  13.75, PRE → next ACT same bank
+...
+```
+
+- Lines starting with `#` are ignored.
+- Whitespace around fields is trimmed.
+- Empty lines are ignored.
+- `unit` is one of `ns` (converted to cycles at load time using `tCK`),
+  `CK` (already in cycles), or `beats` (burst length).
+- `description` is free-form — included in error messages.
+
+## Required parameters (MVP — DDR3)
+
+| Parameter | Description | Used by violation check |
+|---|---|---|
+| `tCK` | Clock period (ns) | Conversion factor — must be first |
+| `tRCD` | Activate to Read/Write | hard: `tRCD` (RD/WR too soon after ACT) |
+| `tRP` | Precharge to Activate | hard: `tRP` (ACT too soon after PRE) |
+| `tRAS_min` | Activate to Precharge min | hard: `tRAS_min` (PRE too soon after ACT) |
+| `tRC` | Active-to-Active same bank | hard: `tRC` |
+| `tWR` | Write recovery | hard: `tWR` (PRE too soon after last WR data beat) |
+| `tWTR` | Write to Read same bank | hard: `tWTR` |
+| `tRTP` | Read to Precharge | hard: `tRTP` (PRE too soon after RD) |
+| `tRRD` | Active-to-Active different bank | hard: `tRRD` |
+| `tFAW` | Four-Activate window | soft: `tFAW` (windowed ACT count) |
+| `tREFI` | Refresh interval (average) | soft: `tREFI` (refresh overdue) |
+| `tRFC` | Refresh cycle time | hard: `tRFC` (command during refresh) |
+| `CL` | CAS latency | reference (read-data timing) |
+| `CWL` | CAS write latency | reference (write-data timing) |
+| `BL` | Burst length (fixed) | reference (beat count) |
+
+## Optional parameters (used when present)
+
+Anything else in the CSV is preserved as raw values in
+`JedecTimings.extras` so future violations can opt in without changing
+the schema. Document new parameters here as they're added.
+
+## Override the violation policy
+
+Hard / soft / ignore sets are configurable per-slave at construction:
+
+```python
+from CocoTBFramework.components.dfi.jedec_timings import load_timings
+from CocoTBFramework.components.dfi.dram_state import ViolationPolicy
+
+timings = load_timings("jedec/ddr3-1600.csv")
+policy = ViolationPolicy(
+    hard={"tRCD", "tRP"},       # only these halt sim
+    soft={"tFAW", "tRRD"},      # these warn
+    ignore={"tREFI"},           # this is silently ignored
+)
+slave = DFISlavePHY(dut, clock, timings=timings, violation_policy=policy)
+```
+
+The defaults (`ViolationPolicy()` with no args) follow the split
+documented in issue #16 — JEDEC-critical timings halt sim, windowed /
+average timings warn, init-sequence specifics are ignored.

--- a/src/CocoTBFramework/components/dfi/jedec/ddr2-650-mt47h64m16hr.csv
+++ b/src/CocoTBFramework/components/dfi/jedec/ddr2-650-mt47h64m16hr.csv
@@ -1,0 +1,37 @@
+# Micron MT47H64M16HR-25:H (1 Gib DDR2, x16) on the Digilent Atlys/Nexys
+# class board. The part is -25 speed grade (rated DDR2-800, tCK_min = 2.5 ns)
+# but the board runs it at DDR2-650 because the 100 MHz oscillator on
+# E3 can be cleanly multiplied to the DDR2-650 frequency via MMCM but
+# not all the way to DDR2-800. Digilent reference value is tCK = 3077 ps
+# (650 Mbps); the part is also valid at tCK = 3000 ps (667 Mbps).
+#
+# Sources:
+#   - Micron MT47H64M16 datasheet (1Gb_DDR2_SDRAM.pdf rev N)
+#   - Digilent board reference manual (recommended clock = 3077 ps)
+#
+# DDR2 differences from the DDR3-1600 reference:
+#   - CWL = CL - 1 (DDR2 convention, not independently programmable)
+#   - BL = 4 (DDR2 default; BL8 is the on-the-fly option)
+#   - Address geometry captured as extras (8 banks × 8192 rows × 1024 cols)
+
+parameter, unit,  value, description
+tCK,       ns,    3.077, Clock period (650 Mbps effective, board MMCM-limited)
+tRCD,      ns,    15.0,  Activate to Read/Write same bank
+tRP,       ns,    15.0,  Precharge command period
+tRAS_min,  ns,    45.0,  Active to Precharge minimum
+tRC,       ns,    60.0,  Active-to-Active same bank
+tWR,       ns,    15.0,  Write recovery (PRE after last WR data beat)
+tWTR,      ns,    7.5,   Write to Read same bank
+tRTP,      ns,    7.5,   Internal Read to Precharge
+tRRD,      ns,    7.5,   Active to Active different bank
+tFAW,      ns,    45.0,  Four-Activate Window (x16 device)
+tREFI,     ns,    7800,  Average refresh interval (8192 rows / 64 ms)
+tRFC,      ns,    127.5, Refresh cycle time (1Gb density)
+CL,        CK,    5,     CAS latency (DDR2-650)
+CWL,       CK,    4,     CAS write latency (= CL - 1, DDR2 convention)
+BL,        beats, 4,     Burst length (BL4 default; BL8 OTF option exists)
+# Address geometry — stashed in extras for the BFM's flat-address mapping
+banks,     CK,    8,     Banks per rank
+rows,      CK,    8192,  Rows per bank
+cols,      CK,    1024,  Columns per row (x16 → 16 bytes per col)
+data_width_bits, CK, 16, DDR x16 organization

--- a/src/CocoTBFramework/components/dfi/jedec/ddr3-1600.csv
+++ b/src/CocoTBFramework/components/dfi/jedec/ddr3-1600.csv
@@ -1,0 +1,21 @@
+# DDR3-1600 (DDR3 1600 MT/s, CL=11) — JEDEC JESD79-3F reference values.
+# Sourced from Micron MT41J512M8 datasheet for the 1600 speed grade.
+# Provisional values for the BFM's DRAM state model; tighten/loosen
+# per the actual part you're modeling.
+
+parameter, unit,  value, description
+tCK,       ns,    1.25,  Clock period (800 MHz DFI clock, DDR3-1600 data rate)
+tRCD,      ns,    13.75, Activate to Read/Write same bank
+tRP,       ns,    13.75, Precharge command period
+tRAS_min,  ns,    35.0,  Active to Precharge minimum
+tRC,       ns,    48.75, Active-to-Active same bank
+tWR,       ns,    15.0,  Write recovery (PRE after last WR data beat)
+tWTR,      ns,    7.5,   Write to Read same bank
+tRTP,      ns,    7.5,   Internal Read to Precharge
+tRRD,      ns,    6.0,   Active to Active different bank
+tFAW,      ns,    30.0,  Four-Activate Window (4 ACT bursts must fit)
+tREFI,     ns,    7800,  Average refresh interval (auto-refresh)
+tRFC,      ns,    260,   Refresh cycle time (per AUTO-REF)
+CL,        CK,    11,    CAS latency
+CWL,       CK,    8,     CAS write latency
+BL,        beats, 8,     Burst length (BL8, fixed)

--- a/src/CocoTBFramework/components/dfi/jedec_timings.py
+++ b/src/CocoTBFramework/components/dfi/jedec_timings.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""JEDEC DRAM timing table loader (issue #16).
+
+The :class:`JedecTimings` dataclass holds the cycle counts the
+:class:`~.dram_state.DramStateModel` needs to check command sequences
+against. CSV format is documented in ``jedec/README.md``.
+
+Pre-alpha note: the CSV schema is provisional. If a parameter the
+checker doesn't know about appears, it's preserved in ``extras`` rather
+than rejected — so the loader stays forward-compatible with new
+timings the user dumps from their own tools.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+_REQUIRED_PARAMS = (
+    "tCK",
+    "tRCD", "tRP", "tRAS_min", "tRC",
+    "tWR", "tWTR", "tRTP", "tRRD",
+    "tFAW", "tREFI", "tRFC",
+    "CL", "CWL", "BL",
+)
+
+
+@dataclass(frozen=True)
+class JedecTimings:
+    """JEDEC timing parameters in DFI clock cycles.
+
+    All ``t*_cycles`` values are converted from the CSV's ``ns`` entries
+    using ``tCK_ns`` (rounded up). ``CL``, ``CWL``, ``BL`` are already
+    in cycles / beats and are stored as-is.
+
+    ``extras`` keeps any parameter the loader didn't recognize so the
+    checker can reach into them without changes to this schema.
+    """
+
+    tCK_ns: float
+    tRCD_cycles: int
+    tRP_cycles: int
+    tRAS_min_cycles: int
+    tRC_cycles: int
+    tWR_cycles: int
+    tWTR_cycles: int
+    tRTP_cycles: int
+    tRRD_cycles: int
+    tFAW_cycles: int
+    tREFI_cycles: int
+    tRFC_cycles: int
+    CL: int
+    CWL: int
+    BL: int
+    extras: Dict[str, float] = field(default_factory=dict)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def ns_to_cycles(ns: float, tCK_ns: float) -> int:
+    """Convert ``ns`` to cycles at ``tCK_ns`` clock period (ceiling).
+
+    Spec convention: round up so the BFM enforces at least the timing
+    the spec calls for. ``ceil(13.75 / 1.25) = 11`` for DDR3-1600 tRCD.
+    """
+    if tCK_ns <= 0:
+        raise ValueError(f"tCK_ns must be positive, got {tCK_ns}")
+    return math.ceil(ns / tCK_ns)
+
+
+def _parse_value(value_str: str, unit: str, tCK_ns: Optional[float]) -> Union[int, float]:
+    """Convert one CSV value to its canonical representation."""
+    unit = unit.strip().lower()
+    raw = float(value_str.strip())
+    if unit == "ns":
+        if tCK_ns is None:
+            raise ValueError("tCK must be the first parameter so ns→cycles "
+                             "conversion has a clock period")
+        return ns_to_cycles(raw, tCK_ns)
+    if unit == "ck":
+        return int(raw)
+    if unit == "beats":
+        return int(raw)
+    raise ValueError(f"Unknown unit {unit!r} — expected ns | CK | beats")
+
+
+# ----------------------------------------------------------------------
+# Public loader
+# ----------------------------------------------------------------------
+
+
+def load_timings(csv_path: Union[str, Path]) -> JedecTimings:
+    """Parse a JEDEC CSV file and return a :class:`JedecTimings`.
+
+    See ``jedec/README.md`` for the format.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        raise FileNotFoundError(f"JEDEC CSV not found: {csv_path}")
+
+    parsed: Dict[str, Union[int, float]] = {}
+    tCK_ns: Optional[float] = None
+
+    with path.open(newline="", encoding="utf-8") as f:
+        # Strip comments before handing to csv.reader; the csv module
+        # doesn't know about '#' comments.
+        cleaned = []
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            cleaned.append(line)
+        reader = csv.reader(cleaned)
+        header = next(reader, None)
+        if header is None:
+            raise ValueError(f"{csv_path}: empty CSV")
+        header = [c.strip().lower() for c in header]
+        expected_header = ["parameter", "unit", "value", "description"]
+        if header != expected_header:
+            raise ValueError(
+                f"{csv_path}: bad header {header!r}; "
+                f"expected {expected_header!r}"
+            )
+        for row in reader:
+            if len(row) < 3:
+                raise ValueError(f"{csv_path}: malformed row {row!r}")
+            name = row[0].strip()
+            unit = row[1].strip()
+            value = row[2].strip()
+            if name == "tCK":
+                # Special case: tCK stores the ns period directly.
+                tCK_ns = float(value)
+                parsed["tCK_ns"] = tCK_ns
+                continue
+            parsed[name] = _parse_value(value, unit, tCK_ns)
+
+    if "tCK_ns" not in parsed:
+        raise ValueError(
+            f"{csv_path}: tCK parameter missing — required as first row "
+            "(needed to convert ns values to cycles)"
+        )
+
+    # Pull required params; anything extra goes into `extras`.
+    required = {p for p in _REQUIRED_PARAMS if p != "tCK"}
+    missing = required - set(parsed.keys())
+    if missing:
+        raise ValueError(
+            f"{csv_path}: missing required parameter(s) "
+            f"{sorted(missing)}"
+        )
+
+    extras = {
+        k: float(v) for k, v in parsed.items()
+        if k not in _REQUIRED_PARAMS and k != "tCK_ns"
+    }
+
+    return JedecTimings(
+        tCK_ns=parsed["tCK_ns"],
+        tRCD_cycles=int(parsed["tRCD"]),
+        tRP_cycles=int(parsed["tRP"]),
+        tRAS_min_cycles=int(parsed["tRAS_min"]),
+        tRC_cycles=int(parsed["tRC"]),
+        tWR_cycles=int(parsed["tWR"]),
+        tWTR_cycles=int(parsed["tWTR"]),
+        tRTP_cycles=int(parsed["tRTP"]),
+        tRRD_cycles=int(parsed["tRRD"]),
+        tFAW_cycles=int(parsed["tFAW"]),
+        tREFI_cycles=int(parsed["tREFI"]),
+        tRFC_cycles=int(parsed["tRFC"]),
+        CL=int(parsed["CL"]),
+        CWL=int(parsed["CWL"]),
+        BL=int(parsed["BL"]),
+        extras=extras,
+    )
+
+
+def builtin_timings(name: str) -> JedecTimings:
+    """Convenience loader for the CSVs vendored in this package.
+
+    Usage:
+        timings = builtin_timings("ddr3-1600")
+    """
+    here = Path(__file__).parent / "jedec"
+    return load_timings(here / f"{name}.csv")

--- a/tests/sim/dfi/test_dfi_loopback.py
+++ b/tests/sim/dfi/test_dfi_loopback.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""End-to-end Tier 2 sim test: DFIMasterMC ⇄ dfi_shim ⇄ DFISlavePHY.
+
+The master writes a few words to a row, then reads them back. The slave
+owns a numpy-backed MemoryModel and commits write data after CWL,
+serving the read CL cycles after the RD command. A monitor on the PHY
+side watches the wire to spot-check the round trip.
+
+This is the first test where the slave's address-mapping, memory
+binding, and timing-aware servicing all run end-to-end against real
+RTL.
+"""
+
+from __future__ import annotations
+
+import os
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_test.simulator import run
+
+from CocoTBFramework.components.dfi import (
+    AddressMapping,
+    DFIBase,
+    DFIMasterMC,
+    DFIMonitor,
+    DFIVersion,
+    MemoryType,
+    builtin_timings,
+)
+from CocoTBFramework.components.dfi.dfi_slave_phy import DFISlavePHY
+from CocoTBFramework.components.shared.memory_model import MemoryModel
+
+
+# ---------------------------------------------------------------------
+# Geometry for tests — small enough to fit in a modest MemoryModel
+# ---------------------------------------------------------------------
+#
+# 4 banks × 32 rows × 32 cols × 8 bytes/beat = 32 KiB total.
+# Picked so flat addresses stay inside the MemoryModel byte range.
+
+BANKS = 4
+ROWS = 32
+COLS = 32
+BYTES_PER_BEAT = 8       # 64-bit data path
+NUM_LINES = BANKS * ROWS * COLS  # one MemoryModel "line" per DFI beat
+
+
+async def _bring_up(dut):
+    cocotb.start_soon(Clock(dut.dfi_clk, 10, units="ns").start())
+    dut.dfi_rstn.value = 0
+    dut.phy_dfi_rddata.value = 0
+    dut.phy_dfi_rddata_valid.value = 0
+    await RisingEdge(dut.dfi_clk)
+    await RisingEdge(dut.dfi_clk)
+    dut.dfi_rstn.value = 1
+    await RisingEdge(dut.dfi_clk)
+
+
+def _make_slave_stack(dut):
+    """Build the DFIBase chassis + AddressMapping + MemoryModel + Slave."""
+    timings = builtin_timings("ddr3-1600")
+    mapping = AddressMapping(
+        num_ranks=1, num_banks=BANKS, num_rows=ROWS, num_cols=COLS,
+    )
+    base = DFIBase(
+        dfi_version=DFIVersion.V2_1,
+        memory_type=MemoryType.DDR3,
+        timings=timings,
+        mapping=mapping,
+    )
+    memory = MemoryModel(num_lines=NUM_LINES, bytes_per_line=BYTES_PER_BEAT)
+    slave = DFISlavePHY(dut, dut.dfi_clk, base=base, memory=memory)
+    return base, memory, slave
+
+
+@cocotb.test(timeout_time=5, timeout_unit="ms")
+async def dfi_write_read_roundtrip_test(dut):
+    """Master writes 4 distinct words, reads them back via the slave."""
+    await _bring_up(dut)
+
+    master = DFIMasterMC(dut, dut.dfi_clk)
+    base, memory, slave = _make_slave_stack(dut)
+    phy_mon = DFIMonitor(dut, dut.dfi_clk, side="phy", title="PHY-mon")
+
+    # Hold rddata_en high — the MVP master uses it as a "MC is ready to
+    # receive" hint; the slave doesn't gate on it but it's good hygiene.
+    master.set_rddata_en(1)
+    await Timer(1, units="ns")
+
+    cwl = base.timings.CWL
+    cl  = base.timings.CL
+    trcd = base.timings.tRCD_cycles
+    trrd = base.timings.tRRD_cycles
+
+    # ----- Writes -----
+
+    payloads = {
+        (1, 0x00): 0x1111_2222_3333_4444,
+        (1, 0x01): 0x5555_6666_7777_8888,
+        (1, 0x02): 0x9999_AAAA_BBBB_CCCC,
+        (1, 0x03): 0xDDDD_EEEE_FFFF_0000,
+    }
+
+    # ACT bank=1, row=0x10
+    await master.activate(bank=1, row=0x10)
+    await master.nop(trcd)
+
+    # Issue 4 WR + write_data pairs spaced by 4 cycles (BL=1 conceptually)
+    for (bank, col), data in payloads.items():
+        await master.write(bank=bank, col=col)
+        # CWL is when the slave expects the data — drive it then
+        await master.nop(cwl - 1)
+        await master.write_data(data=data)
+        await master.nop(2)  # tWTR-ish breathing room
+
+    # Let any in-flight writes drain
+    await master.nop(cwl + 4)
+
+    # ----- Reads -----
+
+    # The slave queues each RD for CL cycles, drives rddata for one cycle.
+    # The PHY-side monitor picks up rddata + rddata_valid every cycle it
+    # fires, so we can read the captured beats off phy_mon.read_data_q.
+    expected_reads_pre = phy_mon.read_data_count
+    for (bank, col), _ in payloads.items():
+        await master.read(bank=bank, col=col)
+        # Spacing — needs to be >= CL so the slave's response lands
+        # before the next read overwrites it.
+        await master.nop(cl + 2)
+
+    # Drain
+    await master.nop(cl + 4)
+
+    dut._log.info(f"slave: {slave}")
+    dut._log.info(f"phy_mon: {phy_mon}")
+
+    # ----- Assertions -----
+
+    # Slave committed all 4 writes
+    assert slave.writes_committed == 4, (
+        f"expected 4 writes committed, got {slave.writes_committed}"
+    )
+    # Slave served all 4 reads
+    assert slave.reads_served == 4, (
+        f"expected 4 reads served, got {slave.reads_served}"
+    )
+
+    # Verify the memory contents directly
+    for (bank, col), expected in payloads.items():
+        flat = base.mapping.tuple_to_flat(0, bank, 0x10, col)
+        byte_addr = flat * BYTES_PER_BEAT
+        ba = memory.read(byte_addr, BYTES_PER_BEAT)
+        got = memory.bytearray_to_integer(ba)
+        assert got == expected, (
+            f"memory[bank={bank} col=0x{col:x} flat=0x{flat:x}] "
+            f"got 0x{got:x} expected 0x{expected:x}"
+        )
+
+    # Verify the monitor captured each read-data beat with the right value.
+    # Order is preserved because we never overlap reads.
+    captured = list(phy_mon.read_data_q)[expected_reads_pre:]
+    assert len(captured) == 4, (
+        f"expected 4 captured read beats, got {len(captured)}"
+    )
+    for (bank, col), expected in payloads.items():
+        # Find the next captured beat
+        beat = captured.pop(0)
+        assert beat.rddata == expected, (
+            f"rddata mismatch for bank={bank} col=0x{col:x}: "
+            f"captured 0x{beat.rddata:x} expected 0x{expected:x}"
+        )
+
+    dut._log.info("End-to-end write/read round-trip passed")
+
+
+# ---------------------------------------------------------------------
+# Pytest runner
+# ---------------------------------------------------------------------
+
+
+def test_dfi_loopback(request):
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    )
+    test_name = "test_dfi_loopback"
+    sim_build = os.path.join(repo_root, "tests", "sim", "local_sim_build", test_name)
+    log_dir = os.path.join(repo_root, "tests", "sim", "logs")
+    os.makedirs(sim_build, exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
+
+    verilog_sources = [
+        os.path.join(repo_root, "tests", "sim", "rtl", "dfi", "dfi_shim.sv"),
+    ]
+    extra_env = {
+        "COCOTB_LOG_LEVEL": "INFO",
+        "COCOTB_RESULTS_FILE": os.path.join(log_dir, f"results_{test_name}.xml"),
+    }
+    extra_args = [
+        "-Wno-TIMESCALEMOD",
+        "-Wno-UNUSED",
+        "-Wno-DECLFILENAME",
+    ]
+
+    run(
+        python_search=[os.path.dirname(__file__)],
+        verilog_sources=verilog_sources,
+        toplevel="dfi_shim",
+        module="test_dfi_loopback",
+        sim_build=sim_build,
+        extra_env=extra_env,
+        extra_args=extra_args,
+        timescale="1ns/1ps",
+        waves=bool(int(os.environ.get("WAVES", "0"))),
+    )

--- a/tests/sim/dfi/test_dfi_shim.py
+++ b/tests/sim/dfi/test_dfi_shim.py
@@ -1,22 +1,21 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2024-2026 sean galloway
 
-"""Tier 2 sim test: DFIMonitor against the dfi_shim passthrough RTL.
+"""Tier 2 sim tests: DFIMasterMC + DFIMonitor against the dfi_shim
+passthrough RTL (issue #16).
 
-This test wires two DFIMonitor instances — one on the MC-facing port
-of dfi_shim, one on the PHY-facing port — and drives a handful of
-DFI v2.1 commands directly onto the MC side. Because dfi_shim is a
-pure passthrough, both monitors must observe identical packet streams.
-That proves:
+The shim is a pure wire passthrough. A :class:`DFIMasterMC` drives the
+MC-facing port via its primitive API (``activate``, ``read``, ``write``,
+``write_data``, ``precharge``, ``refresh``). Two :class:`DFIMonitor`
+instances — one per shim side — verify the same packet stream lands on
+both sides, which proves that:
 
-  - DFIMonitor's cocotb_bus signal binding works for both ``mc_dfi_``
-    and ``phy_dfi_`` prefixes
-  - The (ras_n, cas_n, we_n) → DRAMCommand decode is correct
-  - Per-sub-interface capture queues (command_q, write_data_q,
-    read_data_q) populate in the right order
-
-No master/slave BFM yet — the test drives signals directly so we can
-land the monitor + shim infrastructure in one focused commit.
+  - DFIMasterMC's signal binding works and produces correct
+    (ras_n, cas_n, we_n) encodings for each primitive
+  - DFIMonitor decodes the same wire pattern back to the original
+    :class:`DRAMCommand`
+  - Per-sub-interface capture queues (command_q / write_data_q /
+    read_data_q) populate in the right order on both sides
 """
 
 from __future__ import annotations
@@ -29,157 +28,157 @@ from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer
 from cocotb_test.simulator import run
 
-from CocoTBFramework.components.dfi import DRAMCommand
-from CocoTBFramework.components.dfi.dfi_monitor import DFIMonitor
+from CocoTBFramework.components.dfi import DRAMCommand, DFIMonitor
+from CocoTBFramework.components.dfi.dfi_master_mc import DFIMasterMC
 
 
-# ----- Direct signal-level command issue (no master BFM yet) -----
+# ---------------------------------------------------------------------
+# Shared setup
+# ---------------------------------------------------------------------
 
 
-async def _idle(dut):
-    """Drive the MC-side bus to deselected idle (CS_n high, no data)."""
-    dut.mc_dfi_address.value = 0
-    dut.mc_dfi_bank.value = 0
-    dut.mc_dfi_cs_n.value = 1
-    dut.mc_dfi_ras_n.value = 1
-    dut.mc_dfi_cas_n.value = 1
-    dut.mc_dfi_we_n.value = 1
-    dut.mc_dfi_cke.value = 1
-    dut.mc_dfi_odt.value = 0
-    dut.mc_dfi_reset_n.value = 1
-    dut.mc_dfi_wrdata.value = 0
-    dut.mc_dfi_wrdata_en.value = 0
-    dut.mc_dfi_wrdata_mask.value = 0
-    dut.mc_dfi_rddata_en.value = 0
-
-
-async def _issue_command(dut, ras_n, cas_n, we_n, *, bank=0, addr=0):
-    """Drive a 1-cycle command pulse on the MC side."""
-    dut.mc_dfi_cs_n.value = 0
-    dut.mc_dfi_ras_n.value = ras_n
-    dut.mc_dfi_cas_n.value = cas_n
-    dut.mc_dfi_we_n.value = we_n
-    dut.mc_dfi_bank.value = bank
-    dut.mc_dfi_address.value = addr
-    await RisingEdge(dut.dfi_clk)
-    # Return to deselected idle next cycle
-    dut.mc_dfi_cs_n.value = 1
-    dut.mc_dfi_ras_n.value = 1
-    dut.mc_dfi_cas_n.value = 1
-    dut.mc_dfi_we_n.value = 1
-
-
-# ----- The actual cocotb test -----
-
-
-@cocotb.test(timeout_time=1, timeout_unit="ms")
-async def dfi_shim_dual_monitor_test(dut):
-    """Two monitors on a passthrough shim see identical packet streams."""
-    # Start clock
+async def _bring_up(dut):
+    """Start the clock, hold reset for a few cycles, then release."""
     cocotb.start_soon(Clock(dut.dfi_clk, 10, units="ns").start())
-
-    # Initial conditions
     dut.dfi_rstn.value = 0
-    await _idle(dut)
+    # PHY-side rddata return path stays at 0 unless a test drives it
+    dut.phy_dfi_rddata.value = 0
+    dut.phy_dfi_rddata_valid.value = 0
     await RisingEdge(dut.dfi_clk)
     await RisingEdge(dut.dfi_clk)
     dut.dfi_rstn.value = 1
     await RisingEdge(dut.dfi_clk)
 
-    # Attach two monitors — one per side of the shim
+
+# ---------------------------------------------------------------------
+# Test 1: master primitives → both monitors see the same stream
+# ---------------------------------------------------------------------
+
+
+@cocotb.test(timeout_time=1, timeout_unit="ms")
+async def dfi_master_primitives_test(dut):
+    """Drive each primitive once; both monitors see identical packets."""
+    await _bring_up(dut)
+
+    master = DFIMasterMC(dut, dut.dfi_clk)
     mc_mon = DFIMonitor(dut, dut.dfi_clk, side="mc", title="MC-monitor")
     phy_mon = DFIMonitor(dut, dut.dfi_clk, side="phy", title="PHY-monitor")
-
-    # Let the monitor coroutines spin up
     await Timer(1, units="ns")
 
-    # --- Stimulus: a representative DFI command sequence ---
     # ACT bank=2, row=0x100
-    await _issue_command(dut, ras_n=0, cas_n=1, we_n=1, bank=2, addr=0x100)
-    await RisingEdge(dut.dfi_clk)
-    await RisingEdge(dut.dfi_clk)
+    await master.activate(bank=2, row=0x100)
+    await master.nop(2)
 
     # RD bank=2, col=0x55
-    await _issue_command(dut, ras_n=1, cas_n=0, we_n=1, bank=2, addr=0x55)
-    await RisingEdge(dut.dfi_clk)
+    await master.read(bank=2, col=0x55)
+    await master.nop(1)
 
-    # WR bank=2, col=0xAA
-    await _issue_command(dut, ras_n=1, cas_n=0, we_n=0, bank=2, addr=0xAA)
-
-    # Drive one beat of write data on the WR cycle
-    dut.mc_dfi_wrdata.value = 0xDEADBEEFCAFEBABE
-    dut.mc_dfi_wrdata_en.value = 1
-    dut.mc_dfi_wrdata_mask.value = 0
-    await RisingEdge(dut.dfi_clk)
-    dut.mc_dfi_wrdata_en.value = 0
+    # WR bank=2, col=0xAA + immediate write-data beat
+    await master.write(bank=2, col=0xAA)
+    await master.write_data(data=0xDEADBEEFCAFEBABE, mask=0)
 
     # PRE bank=2
-    await _issue_command(dut, ras_n=0, cas_n=1, we_n=0, bank=2, addr=0)
-    await RisingEdge(dut.dfi_clk)
+    await master.precharge(bank=2)
+    await master.nop(1)
 
-    # REF (all banks)
-    await _issue_command(dut, ras_n=0, cas_n=0, we_n=1, bank=0, addr=0)
-    await RisingEdge(dut.dfi_clk)
+    # REF
+    await master.refresh()
+    await master.nop(1)
 
-    # Drive one beat of read data from the PHY side
+    # Drive a read-data beat from the PHY side (no slave BFM yet)
     dut.phy_dfi_rddata.value = 0x123456789ABCDEF0
     dut.phy_dfi_rddata_valid.value = 1
     await RisingEdge(dut.dfi_clk)
     dut.phy_dfi_rddata_valid.value = 0
 
     # Drain
-    await _idle(dut)
     for _ in range(5):
         await RisingEdge(dut.dfi_clk)
 
+    dut._log.info(f"MC : {mc_mon}")
+    dut._log.info(f"PHY: {phy_mon}")
+
     # ----- Assertions -----
 
-    dut._log.info(f"MC  monitor: {mc_mon}")
-    dut._log.info(f"PHY monitor: {phy_mon}")
+    assert mc_mon.command_count == phy_mon.command_count == 5, (
+        f"command count mismatch: mc={mc_mon.command_count} phy={phy_mon.command_count}"
+    )
+    assert mc_mon.write_data_count == phy_mon.write_data_count == 1
+    assert mc_mon.read_data_count == phy_mon.read_data_count == 1
 
-    # Both monitors must see the same number of each kind of event
-    assert mc_mon.command_count == phy_mon.command_count, (
-        f"command count mismatch mc={mc_mon.command_count} phy={phy_mon.command_count}"
-    )
-    assert mc_mon.write_data_count == phy_mon.write_data_count, (
-        f"write count mismatch mc={mc_mon.write_data_count} phy={phy_mon.write_data_count}"
-    )
-    assert mc_mon.read_data_count == phy_mon.read_data_count, (
-        f"read count mismatch mc={mc_mon.read_data_count} phy={phy_mon.read_data_count}"
-    )
-
-    # 5 commands: ACT, RD, WR, PRE, REF
-    assert mc_mon.command_count == 5, (
-        f"expected 5 commands, got mc={mc_mon.command_count}"
-    )
-    assert mc_mon.write_data_count == 1
-    assert mc_mon.read_data_count == 1
-
-    # Commands in order
     expected = [DRAMCommand.ACT, DRAMCommand.RD, DRAMCommand.WR,
                 DRAMCommand.PRE, DRAMCommand.REF]
-    mc_cmds = [p.cmd for p in mc_mon.command_q]
-    phy_cmds = [p.cmd for p in phy_mon.command_q]
-    assert mc_cmds == expected, f"MC saw {mc_cmds}, expected {expected}"
-    assert phy_cmds == expected, f"PHY saw {phy_cmds}, expected {expected}"
+    assert [p.cmd for p in mc_mon.command_q] == expected
+    assert [p.cmd for p in phy_mon.command_q] == expected
 
-    # Per-packet field-level cross-check (same data crossed the wire)
+    # Per-packet cross-check: same data, both sides
     for mc_p, phy_p in zip(mc_mon.command_q, phy_mon.command_q):
-        assert mc_p.bank == phy_p.bank
-        assert mc_p.address == phy_p.address
-        assert mc_p.cmd == phy_p.cmd
+        assert (mc_p.bank, mc_p.address, mc_p.cmd) == \
+               (phy_p.bank, phy_p.address, phy_p.cmd)
+    assert mc_mon.write_data_q[0].wrdata == phy_mon.write_data_q[0].wrdata == 0xDEADBEEFCAFEBABE
+    assert mc_mon.read_data_q[0].rddata == phy_mon.read_data_q[0].rddata == 0x123456789ABCDEF0
 
-    assert mc_mon.write_data_q[0].wrdata == phy_mon.write_data_q[0].wrdata
-    assert mc_mon.read_data_q[0].rddata == phy_mon.read_data_q[0].rddata
-
-    dut._log.info("DFI shim dual-monitor test passed")
+    dut._log.info("All primitives round-tripped through the shim correctly")
 
 
-# ----- Pytest runner -----
+# ---------------------------------------------------------------------
+# Test 2: a longer command sequence (open row, walk columns, close)
+# ---------------------------------------------------------------------
+
+
+@cocotb.test(timeout_time=1, timeout_unit="ms")
+async def dfi_master_sequence_test(dut):
+    """ACT → 4 × RD → PRE on bank 3, plus a parallel WR sequence on bank 5."""
+    await _bring_up(dut)
+
+    master = DFIMasterMC(dut, dut.dfi_clk)
+    mon = DFIMonitor(dut, dut.dfi_clk, side="phy")
+    await Timer(1, units="ns")
+
+    # Open bank 3, row 0x200
+    await master.activate(bank=3, row=0x200)
+    await master.nop(2)
+    # Walk columns
+    for col in (0x00, 0x10, 0x20, 0x30):
+        await master.read(bank=3, col=col)
+        await master.nop(1)
+    # Close
+    await master.precharge(bank=3)
+    await master.nop(2)
+
+    # Open bank 5, row 0x300, write 2 beats with auto-precharge on the 2nd WR
+    await master.activate(bank=5, row=0x300)
+    await master.nop(2)
+    await master.write(bank=5, col=0x40)
+    await master.write_data(0xAAAAAAAAAAAAAAAA)
+    await master.write(bank=5, col=0x80, auto_precharge=True)
+    await master.write_data(0xBBBBBBBBBBBBBBBB)
+    await master.nop(2)
+
+    for _ in range(5):
+        await RisingEdge(dut.dfi_clk)
+
+    # Expect: ACT, RD, RD, RD, RD, PRE, ACT, WR, WR = 9 commands
+    cmds = [p.cmd for p in mon.command_q]
+    expected = [DRAMCommand.ACT,
+                DRAMCommand.RD, DRAMCommand.RD, DRAMCommand.RD, DRAMCommand.RD,
+                DRAMCommand.PRE,
+                DRAMCommand.ACT,
+                DRAMCommand.WR, DRAMCommand.WR]
+    assert cmds == expected, f"got {cmds}\nexpected {expected}"
+    assert mon.write_data_count == 2
+    # Auto-precharge bit is address[10]
+    second_wr = [p for p in mon.command_q if p.cmd == DRAMCommand.WR][1]
+    assert (second_wr.address >> 10) & 1 == 1, "auto_precharge bit not set"
+
+
+# ---------------------------------------------------------------------
+# Pytest runner
+# ---------------------------------------------------------------------
 
 
 def test_dfi_shim_dual_monitor(request):
-    """Run the dfi_shim_dual_monitor cocotb test against a verilator build."""
+    """Run both cocotb tests against a verilator build of dfi_shim."""
     repo_root = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "..", "..")
     )
@@ -197,7 +196,6 @@ def test_dfi_shim_dual_monitor(request):
         "COCOTB_LOG_LEVEL": "INFO",
         "COCOTB_RESULTS_FILE": os.path.join(log_dir, f"results_{test_name}.xml"),
     }
-
     extra_args = [
         "-Wno-TIMESCALEMOD",
         "-Wno-UNUSED",

--- a/tests/sim/dfi/test_dfi_shim.py
+++ b/tests/sim/dfi/test_dfi_shim.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""Tier 2 sim test: DFIMonitor against the dfi_shim passthrough RTL.
+
+This test wires two DFIMonitor instances — one on the MC-facing port
+of dfi_shim, one on the PHY-facing port — and drives a handful of
+DFI v2.1 commands directly onto the MC side. Because dfi_shim is a
+pure passthrough, both monitors must observe identical packet streams.
+That proves:
+
+  - DFIMonitor's cocotb_bus signal binding works for both ``mc_dfi_``
+    and ``phy_dfi_`` prefixes
+  - The (ras_n, cas_n, we_n) → DRAMCommand decode is correct
+  - Per-sub-interface capture queues (command_q, write_data_q,
+    read_data_q) populate in the right order
+
+No master/slave BFM yet — the test drives signals directly so we can
+land the monitor + shim infrastructure in one focused commit.
+"""
+
+from __future__ import annotations
+
+import os
+
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_test.simulator import run
+
+from CocoTBFramework.components.dfi import DRAMCommand
+from CocoTBFramework.components.dfi.dfi_monitor import DFIMonitor
+
+
+# ----- Direct signal-level command issue (no master BFM yet) -----
+
+
+async def _idle(dut):
+    """Drive the MC-side bus to deselected idle (CS_n high, no data)."""
+    dut.mc_dfi_address.value = 0
+    dut.mc_dfi_bank.value = 0
+    dut.mc_dfi_cs_n.value = 1
+    dut.mc_dfi_ras_n.value = 1
+    dut.mc_dfi_cas_n.value = 1
+    dut.mc_dfi_we_n.value = 1
+    dut.mc_dfi_cke.value = 1
+    dut.mc_dfi_odt.value = 0
+    dut.mc_dfi_reset_n.value = 1
+    dut.mc_dfi_wrdata.value = 0
+    dut.mc_dfi_wrdata_en.value = 0
+    dut.mc_dfi_wrdata_mask.value = 0
+    dut.mc_dfi_rddata_en.value = 0
+
+
+async def _issue_command(dut, ras_n, cas_n, we_n, *, bank=0, addr=0):
+    """Drive a 1-cycle command pulse on the MC side."""
+    dut.mc_dfi_cs_n.value = 0
+    dut.mc_dfi_ras_n.value = ras_n
+    dut.mc_dfi_cas_n.value = cas_n
+    dut.mc_dfi_we_n.value = we_n
+    dut.mc_dfi_bank.value = bank
+    dut.mc_dfi_address.value = addr
+    await RisingEdge(dut.dfi_clk)
+    # Return to deselected idle next cycle
+    dut.mc_dfi_cs_n.value = 1
+    dut.mc_dfi_ras_n.value = 1
+    dut.mc_dfi_cas_n.value = 1
+    dut.mc_dfi_we_n.value = 1
+
+
+# ----- The actual cocotb test -----
+
+
+@cocotb.test(timeout_time=1, timeout_unit="ms")
+async def dfi_shim_dual_monitor_test(dut):
+    """Two monitors on a passthrough shim see identical packet streams."""
+    # Start clock
+    cocotb.start_soon(Clock(dut.dfi_clk, 10, units="ns").start())
+
+    # Initial conditions
+    dut.dfi_rstn.value = 0
+    await _idle(dut)
+    await RisingEdge(dut.dfi_clk)
+    await RisingEdge(dut.dfi_clk)
+    dut.dfi_rstn.value = 1
+    await RisingEdge(dut.dfi_clk)
+
+    # Attach two monitors — one per side of the shim
+    mc_mon = DFIMonitor(dut, dut.dfi_clk, side="mc", title="MC-monitor")
+    phy_mon = DFIMonitor(dut, dut.dfi_clk, side="phy", title="PHY-monitor")
+
+    # Let the monitor coroutines spin up
+    await Timer(1, units="ns")
+
+    # --- Stimulus: a representative DFI command sequence ---
+    # ACT bank=2, row=0x100
+    await _issue_command(dut, ras_n=0, cas_n=1, we_n=1, bank=2, addr=0x100)
+    await RisingEdge(dut.dfi_clk)
+    await RisingEdge(dut.dfi_clk)
+
+    # RD bank=2, col=0x55
+    await _issue_command(dut, ras_n=1, cas_n=0, we_n=1, bank=2, addr=0x55)
+    await RisingEdge(dut.dfi_clk)
+
+    # WR bank=2, col=0xAA
+    await _issue_command(dut, ras_n=1, cas_n=0, we_n=0, bank=2, addr=0xAA)
+
+    # Drive one beat of write data on the WR cycle
+    dut.mc_dfi_wrdata.value = 0xDEADBEEFCAFEBABE
+    dut.mc_dfi_wrdata_en.value = 1
+    dut.mc_dfi_wrdata_mask.value = 0
+    await RisingEdge(dut.dfi_clk)
+    dut.mc_dfi_wrdata_en.value = 0
+
+    # PRE bank=2
+    await _issue_command(dut, ras_n=0, cas_n=1, we_n=0, bank=2, addr=0)
+    await RisingEdge(dut.dfi_clk)
+
+    # REF (all banks)
+    await _issue_command(dut, ras_n=0, cas_n=0, we_n=1, bank=0, addr=0)
+    await RisingEdge(dut.dfi_clk)
+
+    # Drive one beat of read data from the PHY side
+    dut.phy_dfi_rddata.value = 0x123456789ABCDEF0
+    dut.phy_dfi_rddata_valid.value = 1
+    await RisingEdge(dut.dfi_clk)
+    dut.phy_dfi_rddata_valid.value = 0
+
+    # Drain
+    await _idle(dut)
+    for _ in range(5):
+        await RisingEdge(dut.dfi_clk)
+
+    # ----- Assertions -----
+
+    dut._log.info(f"MC  monitor: {mc_mon}")
+    dut._log.info(f"PHY monitor: {phy_mon}")
+
+    # Both monitors must see the same number of each kind of event
+    assert mc_mon.command_count == phy_mon.command_count, (
+        f"command count mismatch mc={mc_mon.command_count} phy={phy_mon.command_count}"
+    )
+    assert mc_mon.write_data_count == phy_mon.write_data_count, (
+        f"write count mismatch mc={mc_mon.write_data_count} phy={phy_mon.write_data_count}"
+    )
+    assert mc_mon.read_data_count == phy_mon.read_data_count, (
+        f"read count mismatch mc={mc_mon.read_data_count} phy={phy_mon.read_data_count}"
+    )
+
+    # 5 commands: ACT, RD, WR, PRE, REF
+    assert mc_mon.command_count == 5, (
+        f"expected 5 commands, got mc={mc_mon.command_count}"
+    )
+    assert mc_mon.write_data_count == 1
+    assert mc_mon.read_data_count == 1
+
+    # Commands in order
+    expected = [DRAMCommand.ACT, DRAMCommand.RD, DRAMCommand.WR,
+                DRAMCommand.PRE, DRAMCommand.REF]
+    mc_cmds = [p.cmd for p in mc_mon.command_q]
+    phy_cmds = [p.cmd for p in phy_mon.command_q]
+    assert mc_cmds == expected, f"MC saw {mc_cmds}, expected {expected}"
+    assert phy_cmds == expected, f"PHY saw {phy_cmds}, expected {expected}"
+
+    # Per-packet field-level cross-check (same data crossed the wire)
+    for mc_p, phy_p in zip(mc_mon.command_q, phy_mon.command_q):
+        assert mc_p.bank == phy_p.bank
+        assert mc_p.address == phy_p.address
+        assert mc_p.cmd == phy_p.cmd
+
+    assert mc_mon.write_data_q[0].wrdata == phy_mon.write_data_q[0].wrdata
+    assert mc_mon.read_data_q[0].rddata == phy_mon.read_data_q[0].rddata
+
+    dut._log.info("DFI shim dual-monitor test passed")
+
+
+# ----- Pytest runner -----
+
+
+def test_dfi_shim_dual_monitor(request):
+    """Run the dfi_shim_dual_monitor cocotb test against a verilator build."""
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    )
+    test_name = "test_dfi_shim_dual_monitor"
+    sim_build = os.path.join(repo_root, "tests", "sim", "local_sim_build", test_name)
+    log_dir = os.path.join(repo_root, "tests", "sim", "logs")
+    os.makedirs(sim_build, exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
+
+    verilog_sources = [
+        os.path.join(repo_root, "tests", "sim", "rtl", "dfi", "dfi_shim.sv"),
+    ]
+
+    extra_env = {
+        "COCOTB_LOG_LEVEL": "INFO",
+        "COCOTB_RESULTS_FILE": os.path.join(log_dir, f"results_{test_name}.xml"),
+    }
+
+    extra_args = [
+        "-Wno-TIMESCALEMOD",
+        "-Wno-UNUSED",
+        "-Wno-DECLFILENAME",
+    ]
+
+    run(
+        python_search=[os.path.dirname(__file__)],
+        verilog_sources=verilog_sources,
+        toplevel="dfi_shim",
+        module="test_dfi_shim",
+        sim_build=sim_build,
+        extra_env=extra_env,
+        extra_args=extra_args,
+        timescale="1ns/1ps",
+        waves=bool(int(os.environ.get("WAVES", "0"))),
+    )

--- a/tests/sim/rtl/dfi/dfi_shim.f
+++ b/tests/sim/rtl/dfi/dfi_shim.f
@@ -1,0 +1,3 @@
+// DFI shim filelist.
+// The shim is self-contained — no dependencies on the parent RTL repo.
+${REPO_ROOT}/tests/sim/rtl/dfi/dfi_shim.sv

--- a/tests/sim/rtl/dfi/dfi_shim.sv
+++ b/tests/sim/rtl/dfi/dfi_shim.sv
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024-2026 sean galloway
+//
+// DFI v2.1 wire shim — passthrough between an MC-side BFM and a PHY-side
+// BFM. The shim has no logic; it lets us attach two monitors (one on each
+// side) and verify they see the same packets, exercising the real cocotb
+// signal-binding path without a behavioral loopback.
+//
+// MVP envelope: DFI v2.1 + DDR1/2/3/LPDDR1/2. 15 signals across the
+// command, write_data, and read_data sub-interfaces. The PHY-facing
+// rddata path (rddata, rddata_valid) is the only direction where the
+// PHY-side BFM drives — everything else is MC-driven.
+
+module dfi_shim #(
+    parameter int ADDR_WIDTH     = 16,
+    parameter int BANK_WIDTH     = 3,
+    parameter int CS_WIDTH       = 1,
+    parameter int CTRL_WIDTH     = 1,
+    parameter int DATA_WIDTH     = 64,
+    parameter int DATA_EN_WIDTH  = 1,
+    parameter int DATA_MASK_BITS = 8,    // data_width / 8
+    parameter int RD_VALID_WIDTH = 1
+) (
+    input  logic dfi_clk,
+    input  logic dfi_rstn,
+
+    // ----- MC-facing port -----
+    // Command sub-interface (MC drives)
+    input  logic [ADDR_WIDTH-1:0]     mc_dfi_address,
+    input  logic [BANK_WIDTH-1:0]     mc_dfi_bank,
+    input  logic [CTRL_WIDTH-1:0]     mc_dfi_cas_n,
+    input  logic [CTRL_WIDTH-1:0]     mc_dfi_ras_n,
+    input  logic [CTRL_WIDTH-1:0]     mc_dfi_we_n,
+    input  logic [CS_WIDTH-1:0]       mc_dfi_cs_n,
+    input  logic [CS_WIDTH-1:0]       mc_dfi_cke,
+    input  logic [CS_WIDTH-1:0]       mc_dfi_odt,
+    input  logic [CS_WIDTH-1:0]       mc_dfi_reset_n,
+    // Write data sub-interface (MC drives)
+    input  logic [DATA_WIDTH-1:0]     mc_dfi_wrdata,
+    input  logic [DATA_EN_WIDTH-1:0]  mc_dfi_wrdata_en,
+    input  logic [DATA_MASK_BITS-1:0] mc_dfi_wrdata_mask,
+    // Read data sub-interface (rddata_en is MC-driven; rddata/_valid are PHY-driven)
+    input  logic [DATA_EN_WIDTH-1:0]  mc_dfi_rddata_en,
+    output logic [DATA_WIDTH-1:0]     mc_dfi_rddata,
+    output logic [RD_VALID_WIDTH-1:0] mc_dfi_rddata_valid,
+
+    // ----- PHY-facing port -----
+    // Command sub-interface (PHY observes)
+    output logic [ADDR_WIDTH-1:0]     phy_dfi_address,
+    output logic [BANK_WIDTH-1:0]     phy_dfi_bank,
+    output logic [CTRL_WIDTH-1:0]     phy_dfi_cas_n,
+    output logic [CTRL_WIDTH-1:0]     phy_dfi_ras_n,
+    output logic [CTRL_WIDTH-1:0]     phy_dfi_we_n,
+    output logic [CS_WIDTH-1:0]       phy_dfi_cs_n,
+    output logic [CS_WIDTH-1:0]       phy_dfi_cke,
+    output logic [CS_WIDTH-1:0]       phy_dfi_odt,
+    output logic [CS_WIDTH-1:0]       phy_dfi_reset_n,
+    // Write data sub-interface (PHY observes)
+    output logic [DATA_WIDTH-1:0]     phy_dfi_wrdata,
+    output logic [DATA_EN_WIDTH-1:0]  phy_dfi_wrdata_en,
+    output logic [DATA_MASK_BITS-1:0] phy_dfi_wrdata_mask,
+    // Read data sub-interface (rddata_en observed; rddata/_valid driven by PHY)
+    output logic [DATA_EN_WIDTH-1:0]  phy_dfi_rddata_en,
+    input  logic [DATA_WIDTH-1:0]     phy_dfi_rddata,
+    input  logic [RD_VALID_WIDTH-1:0] phy_dfi_rddata_valid
+);
+
+    // ----- MC → PHY (command + write-data + rddata_en) -----
+    assign phy_dfi_address     = mc_dfi_address;
+    assign phy_dfi_bank        = mc_dfi_bank;
+    assign phy_dfi_cas_n       = mc_dfi_cas_n;
+    assign phy_dfi_ras_n       = mc_dfi_ras_n;
+    assign phy_dfi_we_n        = mc_dfi_we_n;
+    assign phy_dfi_cs_n        = mc_dfi_cs_n;
+    assign phy_dfi_cke         = mc_dfi_cke;
+    assign phy_dfi_odt         = mc_dfi_odt;
+    assign phy_dfi_reset_n     = mc_dfi_reset_n;
+    assign phy_dfi_wrdata      = mc_dfi_wrdata;
+    assign phy_dfi_wrdata_en   = mc_dfi_wrdata_en;
+    assign phy_dfi_wrdata_mask = mc_dfi_wrdata_mask;
+    assign phy_dfi_rddata_en   = mc_dfi_rddata_en;
+
+    // ----- PHY → MC (read data) -----
+    assign mc_dfi_rddata       = phy_dfi_rddata;
+    assign mc_dfi_rddata_valid = phy_dfi_rddata_valid;
+
+endmodule

--- a/tests/unit/test_dfi_address_mapping.py
+++ b/tests/unit/test_dfi_address_mapping.py
@@ -1,0 +1,168 @@
+"""Unit tests for the DFI BFM address mapping (issue #16).
+
+Models DRAMsim3-style late-binding decode: a mapping string like
+``"row|bank|col"`` dictates the MSB→LSB bit-slice order, geometry
+(num_ranks, num_banks, num_rows, num_cols) sets the field widths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from CocoTBFramework.components.dfi.dram_state import AddressMapping
+
+
+# ---------------------------------------------------------------------
+# Construction / validation
+# ---------------------------------------------------------------------
+
+
+def test_default_mapping_is_row_bank_col():
+    m = AddressMapping(num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024)
+    assert m.mapping == "row|bank|col"
+
+
+def test_rejects_non_power_of_two_banks():
+    with pytest.raises(ValueError, match="power of 2"):
+        AddressMapping(num_ranks=1, num_banks=6, num_rows=8192, num_cols=1024)
+
+
+def test_rejects_non_power_of_two_rows():
+    with pytest.raises(ValueError, match="power of 2"):
+        AddressMapping(num_ranks=1, num_banks=8, num_rows=8000, num_cols=1024)
+
+
+def test_rejects_unknown_field_in_mapping():
+    with pytest.raises(ValueError, match="unknown field"):
+        AddressMapping(
+            mapping="row|bogus|col",
+            num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024,
+        )
+
+
+def test_rejects_duplicate_field_in_mapping():
+    with pytest.raises(ValueError, match="duplicate"):
+        AddressMapping(
+            mapping="row|bank|row",
+            num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024,
+        )
+
+
+def test_rejects_missing_required_field():
+    """col must appear in the mapping (you can't address into a row
+    without it). Same for bank when num_banks > 1."""
+    with pytest.raises(ValueError, match="missing"):
+        AddressMapping(
+            mapping="row|bank",  # no col
+            num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024,
+        )
+
+
+def test_rank_field_optional_when_single_rank():
+    """Single-rank DIMM (the MT47H64M16HR-25:H case): 'rank' may be
+    omitted from the mapping string entirely."""
+    m = AddressMapping(
+        mapping="row|bank|col",
+        num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024,
+    )
+    rank, bank, row, col = m.flat_to_tuple(0)
+    assert rank == 0
+
+
+def test_rank_field_required_when_multi_rank():
+    with pytest.raises(ValueError, match="rank"):
+        AddressMapping(
+            mapping="row|bank|col",  # missing rank
+            num_ranks=2, num_banks=8, num_rows=8192, num_cols=1024,
+        )
+
+
+# ---------------------------------------------------------------------
+# flat_to_tuple / tuple_to_flat round-trip
+# ---------------------------------------------------------------------
+
+
+def test_round_trip_single_rank():
+    m = AddressMapping(num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024)
+    for r, b, row, col in [
+        (0, 0, 0, 0),
+        (0, 7, 8191, 1023),
+        (0, 3, 0x100, 0x55),
+        (0, 5, 0x1234, 0x2AA),
+    ]:
+        flat = m.tuple_to_flat(r, b, row, col)
+        assert m.flat_to_tuple(flat) == (r, b, row, col)
+
+
+def test_round_trip_multi_rank():
+    m = AddressMapping(
+        mapping="rank|row|bank|col",
+        num_ranks=2, num_banks=8, num_rows=8192, num_cols=1024,
+    )
+    for r, b, row, col in [
+        (0, 0, 0, 0),
+        (1, 7, 8191, 1023),
+        (1, 4, 0xABC, 0x123),
+    ]:
+        flat = m.tuple_to_flat(r, b, row, col)
+        assert m.flat_to_tuple(flat) == (r, b, row, col)
+
+
+# ---------------------------------------------------------------------
+# Bit-slice order matches the mapping string
+# ---------------------------------------------------------------------
+
+
+def test_row_bank_col_layout():
+    """For row|bank|col with 8 banks (3b), 8192 rows (13b), 1024 cols (10b):
+        flat[25:13] = row, flat[12:10] = bank, flat[9:0] = col
+    """
+    m = AddressMapping(
+        mapping="row|bank|col",
+        num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024,
+    )
+    # row=1, bank=0, col=0 → bit 13 set
+    assert m.tuple_to_flat(0, 0, 1, 0) == (1 << 13)
+    # row=0, bank=1, col=0 → bit 10 set
+    assert m.tuple_to_flat(0, 1, 0, 0) == (1 << 10)
+    # row=0, bank=0, col=1 → bit 0 set
+    assert m.tuple_to_flat(0, 0, 0, 1) == 1
+
+
+def test_row_col_bank_layout_swaps_bank_and_col():
+    """row|col|bank places bank in the LSBs — column-major-ish layout.
+        flat[25:13] = row, flat[12:3] = col, flat[2:0] = bank
+    """
+    m = AddressMapping(
+        mapping="row|col|bank",
+        num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024,
+    )
+    # bank=1 → bit 0 set
+    assert m.tuple_to_flat(0, 1, 0, 0) == 1
+    # col=1 → bit 3 set (above bank bits)
+    assert m.tuple_to_flat(0, 0, 0, 1) == (1 << 3)
+
+
+# ---------------------------------------------------------------------
+# Range checking
+# ---------------------------------------------------------------------
+
+
+def test_tuple_to_flat_rejects_out_of_range():
+    m = AddressMapping(num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024)
+    with pytest.raises(ValueError, match="bank"):
+        m.tuple_to_flat(0, 8, 0, 0)  # bank 8 invalid (0..7)
+    with pytest.raises(ValueError, match="row"):
+        m.tuple_to_flat(0, 0, 8192, 0)
+    with pytest.raises(ValueError, match="col"):
+        m.tuple_to_flat(0, 0, 0, 1024)
+
+
+# ---------------------------------------------------------------------
+# total_size — number of distinct flat addresses
+# ---------------------------------------------------------------------
+
+
+def test_total_size_matches_geometry_product():
+    m = AddressMapping(num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024)
+    assert m.total_size == 1 * 8 * 8192 * 1024

--- a/tests/unit/test_dfi_base.py
+++ b/tests/unit/test_dfi_base.py
@@ -1,0 +1,139 @@
+"""Unit tests for the DFIBase chassis (issue #16).
+
+DFIBase is the shared configuration + sub-interface registry that
+DFIMasterMC / DFISlavePHY / DFIMonitor all inherit. It owns nothing
+cocotb-specific — that lives in the subclasses — so it's Tier 1
+testable in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from CocoTBFramework.components.dfi import (
+    AddressMapping,
+    DFIVersion,
+    MemoryType,
+    SubInterface,
+    builtin_timings,
+)
+from CocoTBFramework.components.dfi.dfi_base import DFIBase
+
+
+@pytest.fixture
+def timings():
+    return builtin_timings("ddr3-1600")
+
+
+@pytest.fixture
+def mapping():
+    return AddressMapping(num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024)
+
+
+@pytest.fixture
+def base(timings, mapping):
+    return DFIBase(
+        dfi_version=DFIVersion.V2_1,
+        memory_type=MemoryType.DDR3,
+        timings=timings,
+        mapping=mapping,
+    )
+
+
+# ---------------------------------------------------------------------
+# Construction / configuration validation
+# ---------------------------------------------------------------------
+
+
+def test_base_stores_configuration(base, timings, mapping):
+    assert base.dfi_version == DFIVersion.V2_1
+    assert base.memory_type == MemoryType.DDR3
+    assert base.timings is timings
+    assert base.mapping is mapping
+
+
+def test_base_rejects_unsupported_version_memory_pair(timings, mapping):
+    """v2.1 + DDR5 is not a supported pair."""
+    with pytest.raises(ValueError, match="not supported"):
+        DFIBase(
+            dfi_version=DFIVersion.V2_1,
+            memory_type=MemoryType.DDR5,
+            timings=timings,
+            mapping=mapping,
+        )
+
+
+def test_base_defaults_sub_interfaces_to_mvp_set(base):
+    """MVP: command + write_data + read_data sub-interfaces enabled."""
+    enabled = base.enabled_sub_interfaces
+    assert SubInterface.COMMAND in enabled
+    assert SubInterface.WRITE_DATA in enabled
+    assert SubInterface.READ_DATA in enabled
+
+
+def test_base_accepts_custom_sub_interfaces(timings, mapping):
+    """Caller can restrict to a subset — e.g. command-only for a stub."""
+    base = DFIBase(
+        dfi_version=DFIVersion.V2_1,
+        memory_type=MemoryType.DDR3,
+        timings=timings,
+        mapping=mapping,
+        sub_interfaces=frozenset({SubInterface.COMMAND}),
+    )
+    assert base.enabled_sub_interfaces == frozenset({SubInterface.COMMAND})
+
+
+# ---------------------------------------------------------------------
+# Cycle counter
+# ---------------------------------------------------------------------
+
+
+def test_cycle_starts_at_zero(base):
+    assert base.cycle == 0
+
+
+def test_tick_advances_cycle(base):
+    base.tick()
+    base.tick()
+    assert base.cycle == 2
+
+
+# ---------------------------------------------------------------------
+# Field-config dispatch
+# ---------------------------------------------------------------------
+
+
+def test_field_config_for_each_enabled_sub_interface(base):
+    """Each enabled sub-interface has a corresponding field config."""
+    cmd_cfg = base.field_config_for(SubInterface.COMMAND)
+    wr_cfg = base.field_config_for(SubInterface.WRITE_DATA)
+    rd_cfg = base.field_config_for(SubInterface.READ_DATA)
+    assert cmd_cfg is not None
+    assert wr_cfg is not None
+    assert rd_cfg is not None
+    # Different sub-interfaces should produce different field configs
+    assert cmd_cfg is not wr_cfg
+
+
+def test_field_config_for_disabled_sub_interface_raises(timings, mapping):
+    base = DFIBase(
+        dfi_version=DFIVersion.V2_1,
+        memory_type=MemoryType.DDR3,
+        timings=timings,
+        mapping=mapping,
+        sub_interfaces=frozenset({SubInterface.COMMAND}),
+    )
+    with pytest.raises(ValueError, match="not enabled"):
+        base.field_config_for(SubInterface.WRITE_DATA)
+
+
+# ---------------------------------------------------------------------
+# Address widths derived from mapping
+# ---------------------------------------------------------------------
+
+
+def test_widths_match_mapping(base):
+    """The chassis exposes the widths needed to size DFI signals."""
+    assert base.bank_width == 3   # ceil(log2(8))
+    assert base.row_width == 13   # ceil(log2(8192))
+    assert base.col_width == 10   # ceil(log2(1024))

--- a/tests/unit/test_dfi_dram_state.py
+++ b/tests/unit/test_dfi_dram_state.py
@@ -1,0 +1,244 @@
+"""Unit tests for the DRAM state model + JEDEC timing checker (issue #16)."""
+
+from __future__ import annotations
+
+import pytest
+
+from CocoTBFramework.components.dfi.dram_state import (
+    BankState,
+    DramStateModel,
+    ViolationCategory,
+    ViolationPolicy,
+)
+from CocoTBFramework.components.dfi.jedec_timings import builtin_timings
+
+
+@pytest.fixture
+def timings():
+    return builtin_timings("ddr3-1600")
+
+
+@pytest.fixture
+def model(timings):
+    return DramStateModel(timings=timings, num_banks=8)
+
+
+def _advance(m: DramStateModel, n: int) -> None:
+    for _ in range(n):
+        m.tick()
+
+
+# ---------------------------------------------------------------------
+# ViolationPolicy
+# ---------------------------------------------------------------------
+
+
+def test_policy_defaults_to_proposed_split():
+    p = ViolationPolicy()
+    assert p.category_of("tRCD") == ViolationCategory.HARD
+    assert p.category_of("tFAW") == ViolationCategory.SOFT
+    assert p.category_of("init_sequence") == ViolationCategory.IGNORE
+
+
+def test_policy_unknown_name_defaults_to_soft():
+    """Forward-compat: a violation we haven't categorized yet warns
+    rather than crashing the sim or being silently dropped."""
+    p = ViolationPolicy()
+    assert p.category_of("tFutureNewTiming") == ViolationCategory.SOFT
+
+
+def test_policy_hard_raises():
+    p = ViolationPolicy()
+    with pytest.raises(AssertionError, match="tRCD"):
+        p.report("tRCD", "context here")
+
+
+def test_policy_soft_logs_and_counts(caplog):
+    p = ViolationPolicy()
+    import logging
+    log = logging.getLogger("test")
+    with caplog.at_level(logging.WARNING):
+        p.report("tFAW", "first context", log)
+        p.report("tFAW", "second context", log)
+    assert p.soft_violation_counts == {"tFAW": 2}
+
+
+def test_policy_ignore_is_silent():
+    p = ViolationPolicy()
+    # Should not raise, should not count
+    p.report("init_sequence", "irrelevant")
+    assert "init_sequence" not in p.soft_violation_counts
+
+
+def test_policy_override_hard_to_soft(caplog):
+    """User can override defaults to make tRCD a warning instead of fatal."""
+    p = ViolationPolicy(
+        hard=frozenset(),                  # nothing is fatal
+        soft=frozenset({"tRCD"}),
+        ignore=frozenset(),
+    )
+    import logging
+    with caplog.at_level(logging.WARNING):
+        p.report("tRCD", "downgraded", logging.getLogger("test"))
+    assert p.soft_violation_counts == {"tRCD": 1}
+
+
+# ---------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------
+
+
+def test_model_starts_all_idle(model):
+    for b in model.banks:
+        assert b.state == BankState.IDLE
+        assert b.row is None
+
+
+def test_model_rejects_zero_banks(timings):
+    with pytest.raises(ValueError, match="num_banks"):
+        DramStateModel(timings=timings, num_banks=0)
+
+
+# ---------------------------------------------------------------------
+# Bank-state transitions
+# ---------------------------------------------------------------------
+
+
+def test_activate_marks_bank_active(model):
+    model.on_activate(bank_idx=2, row=0x100)
+    assert model.banks[2].state == BankState.ACTIVE
+    assert model.banks[2].row == 0x100
+
+
+def test_activate_on_already_active_bank_is_hard(model):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, 50)  # past all relevant timings
+    with pytest.raises(AssertionError, match="already ACTIVE"):
+        model.on_activate(bank_idx=0, row=0x200)
+
+
+def test_read_without_activate_is_hard(model):
+    with pytest.raises(AssertionError, match="no_act_before_rd"):
+        model.on_read(bank_idx=3)
+
+
+def test_write_without_activate_is_hard(model):
+    with pytest.raises(AssertionError, match="no_act_before_wr"):
+        model.on_write(bank_idx=3)
+
+
+def test_precharge_returns_bank_to_idle(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRAS_min_cycles)
+    model.on_precharge(bank_idx=0)
+    assert model.banks[0].state == BankState.IDLE
+    assert model.banks[0].row is None
+
+
+# ---------------------------------------------------------------------
+# Per-bank timing checks
+# ---------------------------------------------------------------------
+
+
+def test_read_before_tRCD_is_hard(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRCD_cycles - 2)  # one short
+    with pytest.raises(AssertionError, match="tRCD"):
+        model.on_read(bank_idx=0)
+
+
+def test_read_after_tRCD_succeeds(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRCD_cycles)  # exactly enough
+    model.on_read(bank_idx=0)  # no raise
+
+
+def test_write_before_tRCD_is_hard(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRCD_cycles - 2)
+    with pytest.raises(AssertionError, match="tRCD"):
+        model.on_write(bank_idx=0)
+
+
+def test_precharge_before_tRAS_is_hard(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    # Don't wait long enough
+    _advance(model, 5)
+    with pytest.raises(AssertionError, match="tRAS_min"):
+        model.on_precharge(bank_idx=0)
+
+
+def test_act_after_pre_before_tRP_is_hard(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRAS_min_cycles)
+    model.on_precharge(bank_idx=0)
+    _advance(model, timings.tRP_cycles - 2)
+    with pytest.raises(AssertionError, match="tRP"):
+        model.on_activate(bank_idx=0, row=0x200)
+
+
+def test_act_to_act_diff_bank_before_tRRD_is_hard(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRRD_cycles - 2)  # one short
+    with pytest.raises(AssertionError, match="tRRD"):
+        model.on_activate(bank_idx=1, row=0x100)
+
+
+def test_act_to_act_diff_bank_at_tRRD_succeeds(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRRD_cycles)
+    model.on_activate(bank_idx=1, row=0x100)  # no raise
+
+
+# ---------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------
+
+
+def test_refresh_with_open_row_is_hard(model, timings):
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRAS_min_cycles)
+    with pytest.raises(AssertionError, match="ref_with_open_row"):
+        model.on_refresh()
+
+
+def test_refresh_after_all_pre_succeeds(model, timings):
+    # Activate then precharge → all banks idle
+    model.on_activate(bank_idx=0, row=0x100)
+    _advance(model, timings.tRAS_min_cycles)
+    model.on_precharge(bank_idx=0, all_banks=False)
+    model.on_refresh()  # no raise
+    assert all(b.state == BankState.REFRESHING for b in model.banks)
+
+
+def test_cmd_during_refresh_is_hard(model, timings):
+    model.on_refresh()
+    # Try an ACT during refresh
+    _advance(model, 5)
+    with pytest.raises(AssertionError, match="cmd_during_refresh"):
+        model.on_activate(bank_idx=0, row=0x100)
+
+
+def test_refresh_completes_after_tRFC(model, timings):
+    model.on_refresh()
+    _advance(model, timings.tRFC_cycles)
+    assert all(b.state == BankState.IDLE for b in model.banks)
+
+
+# ---------------------------------------------------------------------
+# Policy override at construction
+# ---------------------------------------------------------------------
+
+
+def test_constructor_accepts_custom_policy(timings, caplog):
+    """Caller can downgrade tRCD to a warning."""
+    custom = ViolationPolicy(
+        hard=frozenset(),  # nothing fatal
+        soft=frozenset({"tRCD"}),
+        ignore=frozenset(),
+    )
+    m = DramStateModel(timings=timings, num_banks=8, policy=custom)
+    m.on_activate(bank_idx=0, row=0x100)
+    # Read way too soon — should warn, not raise
+    m.on_read(bank_idx=0)
+    assert custom.soft_violation_counts.get("tRCD", 0) >= 1

--- a/tests/unit/test_dfi_field_configs.py
+++ b/tests/unit/test_dfi_field_configs.py
@@ -1,0 +1,103 @@
+"""Unit tests for DFI field-config builders (issue #16)."""
+
+from __future__ import annotations
+
+from CocoTBFramework.components.dfi.dfi_field_configs import (
+    control_field_config,
+    read_data_field_config,
+    write_data_field_config,
+)
+from CocoTBFramework.components.dfi.dfi_signals import MemoryType
+
+
+# ---------------------------------------------------------------------
+# Control interface field configs
+# ---------------------------------------------------------------------
+
+
+def test_control_ddr3_includes_reset_n_and_odt():
+    cfg = control_field_config(memory_type=MemoryType.DDR3)
+    names = list(cfg.field_names())
+    assert "reset_n" in names  # DDR3-only
+    assert "odt" in names      # DDR2/DDR3
+    assert "bank" in names     # DDR1+
+
+
+def test_control_ddr2_includes_odt_excludes_reset_n():
+    cfg = control_field_config(memory_type=MemoryType.DDR2)
+    names = list(cfg.field_names())
+    assert "odt" in names
+    assert "reset_n" not in names
+
+
+def test_control_lpddr2_excludes_idled_signals():
+    cfg = control_field_config(memory_type=MemoryType.LPDDR2)
+    names = list(cfg.field_names())
+    assert "address" in names
+    # bank/ras_n/cas_n/we_n are held idle for LPDDR2 — not in the config
+    assert "bank" not in names
+    assert "ras_n" not in names
+    assert "cas_n" not in names
+    assert "we_n" not in names
+
+
+def test_control_width_arguments_propagate():
+    cfg = control_field_config(
+        memory_type=MemoryType.DDR3,
+        addr_width=20,
+        bank_width=4,
+    )
+    addr_field = cfg.get_field("address")
+    bank_field = cfg.get_field("bank")
+    assert addr_field.bits == 20
+    assert bank_field.bits == 4
+
+
+# ---------------------------------------------------------------------
+# Write data field configs
+# ---------------------------------------------------------------------
+
+
+def test_write_data_fields_present():
+    cfg = write_data_field_config(memory_type=MemoryType.DDR3, data_width=64)
+    names = set(cfg.field_names())
+    assert names == {"wrdata", "wrdata_en", "wrdata_mask"}
+
+
+def test_write_data_mask_width_is_data_width_div_8():
+    cfg = write_data_field_config(memory_type=MemoryType.DDR3, data_width=64)
+    assert cfg.get_field("wrdata").bits == 64
+    assert cfg.get_field("wrdata_mask").bits == 8  # 64 / 8
+
+
+def test_write_data_mask_width_for_32_bit_path():
+    cfg = write_data_field_config(memory_type=MemoryType.DDR3, data_width=32)
+    assert cfg.get_field("wrdata_mask").bits == 4
+
+
+# ---------------------------------------------------------------------
+# Read data field configs
+# ---------------------------------------------------------------------
+
+
+def test_read_data_ddr3_excludes_dnv():
+    cfg = read_data_field_config(memory_type=MemoryType.DDR3)
+    names = list(cfg.field_names())
+    assert "rddata_dnv" not in names
+
+
+def test_read_data_lpddr2_includes_dnv():
+    cfg = read_data_field_config(memory_type=MemoryType.LPDDR2)
+    names = list(cfg.field_names())
+    assert "rddata_dnv" in names
+    assert cfg.get_field("rddata_dnv").bits == 8  # data_width / 8
+
+
+def test_read_data_widths():
+    cfg = read_data_field_config(
+        memory_type=MemoryType.DDR3,
+        data_width=128,
+        rd_valid_width=2,
+    )
+    assert cfg.get_field("rddata").bits == 128
+    assert cfg.get_field("rddata_valid").bits == 2

--- a/tests/unit/test_dfi_field_configs.py
+++ b/tests/unit/test_dfi_field_configs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from CocoTBFramework.components.dfi.dfi_field_configs import (
-    control_field_config,
+    command_field_config,
     read_data_field_config,
     write_data_field_config,
 )
@@ -16,7 +16,7 @@ from CocoTBFramework.components.dfi.dfi_signals import MemoryType
 
 
 def test_control_ddr3_includes_reset_n_and_odt():
-    cfg = control_field_config(memory_type=MemoryType.DDR3)
+    cfg = command_field_config(memory_type=MemoryType.DDR3)
     names = list(cfg.field_names())
     assert "reset_n" in names  # DDR3-only
     assert "odt" in names      # DDR2/DDR3
@@ -24,14 +24,14 @@ def test_control_ddr3_includes_reset_n_and_odt():
 
 
 def test_control_ddr2_includes_odt_excludes_reset_n():
-    cfg = control_field_config(memory_type=MemoryType.DDR2)
+    cfg = command_field_config(memory_type=MemoryType.DDR2)
     names = list(cfg.field_names())
     assert "odt" in names
     assert "reset_n" not in names
 
 
 def test_control_lpddr2_excludes_idled_signals():
-    cfg = control_field_config(memory_type=MemoryType.LPDDR2)
+    cfg = command_field_config(memory_type=MemoryType.LPDDR2)
     names = list(cfg.field_names())
     assert "address" in names
     # bank/ras_n/cas_n/we_n are held idle for LPDDR2 — not in the config
@@ -42,7 +42,7 @@ def test_control_lpddr2_excludes_idled_signals():
 
 
 def test_control_width_arguments_propagate():
-    cfg = control_field_config(
+    cfg = command_field_config(
         memory_type=MemoryType.DDR3,
         addr_width=20,
         bank_width=4,

--- a/tests/unit/test_dfi_jedec_timings.py
+++ b/tests/unit/test_dfi_jedec_timings.py
@@ -1,0 +1,187 @@
+"""Unit tests for JEDEC timing CSV loader (issue #16)."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from CocoTBFramework.components.dfi.jedec_timings import (
+    JedecTimings,
+    builtin_timings,
+    load_timings,
+    ns_to_cycles,
+)
+
+
+# ---------------------------------------------------------------------
+# ns_to_cycles arithmetic
+# ---------------------------------------------------------------------
+
+
+def test_ns_to_cycles_rounds_up():
+    """Spec convention: ceil so the BFM enforces at least the timing
+    the spec calls for. 13.75 / 1.25 = 11.0 exactly here."""
+    assert ns_to_cycles(13.75, 1.25) == 11
+
+
+def test_ns_to_cycles_rounds_up_when_not_exact():
+    """ceil(15.0 / 1.25) = ceil(12.0) = 12, but 14.99/1.25 = 11.99 → 12."""
+    assert ns_to_cycles(14.99, 1.25) == 12
+
+
+def test_ns_to_cycles_rejects_zero_clock():
+    with pytest.raises(ValueError, match="tCK_ns must be positive"):
+        ns_to_cycles(13.75, 0)
+
+
+# ---------------------------------------------------------------------
+# Builtin DDR3-1600 CSV
+# ---------------------------------------------------------------------
+
+
+def test_builtin_ddr3_1600_loads_clean():
+    t = builtin_timings("ddr3-1600")
+    assert isinstance(t, JedecTimings)
+    assert t.tCK_ns == 1.25
+    # DDR3-1600 standard: tRCD = 13.75 ns → 11 cycles at 800 MHz DFI clock
+    assert t.tRCD_cycles == 11
+    assert t.tRP_cycles == 11
+    assert t.CL == 11
+    assert t.CWL == 8
+    assert t.BL == 8
+
+
+def test_builtin_ddr3_1600_tras_correct():
+    t = builtin_timings("ddr3-1600")
+    # tRAS_min = 35.0 ns → ceil(35.0 / 1.25) = 28 cycles
+    assert t.tRAS_min_cycles == 28
+
+
+# ---------------------------------------------------------------------
+# CSV parsing — happy path
+# ---------------------------------------------------------------------
+
+
+def _write_csv(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "test.csv"
+    p.write_text(dedent(content))
+    return p
+
+
+def test_csv_strips_comments_and_blanks(tmp_path):
+    p = _write_csv(tmp_path, """
+        # comment line 1
+
+        # comment line 2
+        parameter, unit, value, description
+        tCK,       ns,   1.25,  clock
+        tRCD,      ns,   13.75, ACT to RD
+        tRP,       ns,   13.75, PRE
+        tRAS_min,  ns,   35.0,  ACT to PRE
+        tRC,       ns,   48.75, ACT to ACT
+        tWR,       ns,   15.0,  write recovery
+        tWTR,      ns,   7.5,   WR to RD
+        tRTP,      ns,   7.5,   RD to PRE
+        tRRD,      ns,   6.0,   ACT to ACT diff bank
+        tFAW,      ns,   30.0,  4 ACT window
+        tREFI,     ns,   7800,  refresh interval
+        tRFC,      ns,   260,   refresh cycle
+        CL,        CK,   11,    CAS latency
+        CWL,       CK,   8,     CAS write latency
+        BL,        beats,8,     burst length
+    """)
+    t = load_timings(p)
+    assert t.tCK_ns == 1.25
+    assert t.tRCD_cycles == 11
+
+
+def test_csv_passes_through_extras(tmp_path):
+    """Unknown parameters get stashed in .extras for forward compat."""
+    p = _write_csv(tmp_path, """
+        parameter, unit, value, description
+        tCK,       ns,   1.25,  clock
+        tRCD,      ns,   13.75, _
+        tRP,       ns,   13.75, _
+        tRAS_min,  ns,   35.0,  _
+        tRC,       ns,   48.75, _
+        tWR,       ns,   15.0,  _
+        tWTR,      ns,   7.5,   _
+        tRTP,      ns,   7.5,   _
+        tRRD,      ns,   6.0,   _
+        tFAW,      ns,   30.0,  _
+        tREFI,     ns,   7800,  _
+        tRFC,      ns,   260,   _
+        CL,        CK,   11,    _
+        CWL,       CK,   8,     _
+        BL,        beats,8,     _
+        tXYZ_future, CK, 42,    future param the loader doesn't know
+    """)
+    t = load_timings(p)
+    assert "tXYZ_future" in t.extras
+    assert t.extras["tXYZ_future"] == 42
+
+
+# ---------------------------------------------------------------------
+# CSV parsing — error paths
+# ---------------------------------------------------------------------
+
+
+def test_load_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        load_timings("/nonexistent/path.csv")
+
+
+def test_load_missing_tCK_raises(tmp_path):
+    p = _write_csv(tmp_path, """
+        parameter, unit, value, description
+        tRCD,      ns,   13.75, _
+    """)
+    with pytest.raises(ValueError, match="tCK"):
+        load_timings(p)
+
+
+def test_load_missing_required_param_raises(tmp_path):
+    p = _write_csv(tmp_path, """
+        parameter, unit, value, description
+        tCK,       ns,   1.25,  _
+        tRCD,      ns,   13.75, _
+    """)
+    # tRP and friends are missing
+    with pytest.raises(ValueError, match="missing required parameter"):
+        load_timings(p)
+
+
+def test_load_bad_header_raises(tmp_path):
+    p = _write_csv(tmp_path, """
+        wrong, header, here
+        tCK,   ns,     1.25
+    """)
+    with pytest.raises(ValueError, match="bad header"):
+        load_timings(p)
+
+
+def test_load_unknown_unit_raises(tmp_path):
+    """An unknown unit should be a clear error, not silent corruption."""
+    p = _write_csv(tmp_path, """
+        parameter, unit, value, description
+        tCK,       ns,   1.25,  _
+        tRCD,      bogus,13.75, _
+        tRP,       ns,   13.75, _
+        tRAS_min,  ns,   35.0,  _
+        tRC,       ns,   48.75, _
+        tWR,       ns,   15.0,  _
+        tWTR,      ns,   7.5,   _
+        tRTP,      ns,   7.5,   _
+        tRRD,      ns,   6.0,   _
+        tFAW,      ns,   30.0,  _
+        tREFI,     ns,   7800,  _
+        tRFC,      ns,   260,   _
+        CL,        CK,   11,    _
+        CWL,       CK,   8,     _
+        BL,        beats,8,     _
+    """)
+    with pytest.raises(ValueError, match="Unknown unit"):
+        load_timings(p)

--- a/tests/unit/test_dfi_packet.py
+++ b/tests/unit/test_dfi_packet.py
@@ -1,0 +1,150 @@
+"""Unit tests for DFI packet types (issue #16)."""
+
+from __future__ import annotations
+
+import pytest
+
+from CocoTBFramework.components.dfi.dfi_packet import (
+    DFIControlPacket,
+    DFIReadDataPacket,
+    DFIWriteDataPacket,
+    DRAMCommand,
+)
+from CocoTBFramework.components.dfi.dfi_signals import MemoryType
+
+
+# ---------------------------------------------------------------------
+# DRAMCommand encoding via DFIControlPacket.from_command
+# ---------------------------------------------------------------------
+
+
+def test_deselect_holds_cs_n_high():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.DESEL, memory_type=MemoryType.DDR3,
+    )
+    assert pkt.cs_n == 1  # CS_n deasserted = no command
+
+
+def test_activate_encoding_ras_low_others_high():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.ACT, memory_type=MemoryType.DDR3,
+        address=0x1234, bank=2,
+    )
+    assert pkt.cs_n == 0
+    assert pkt.ras_n == 0   # ACT asserts RAS
+    assert pkt.cas_n == 1
+    assert pkt.we_n == 1
+    assert pkt.address == 0x1234
+    assert pkt.bank == 2
+
+
+def test_read_encoding_cas_low_we_high():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.RD, memory_type=MemoryType.DDR3,
+        bank=3, address=0x40,
+    )
+    assert pkt.ras_n == 1
+    assert pkt.cas_n == 0
+    assert pkt.we_n == 1
+
+
+def test_write_encoding_cas_low_we_low():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.WR, memory_type=MemoryType.DDR3,
+    )
+    assert pkt.ras_n == 1
+    assert pkt.cas_n == 0
+    assert pkt.we_n == 0
+
+
+def test_precharge_encoding_ras_we_low():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.PRE, memory_type=MemoryType.DDR3,
+    )
+    assert pkt.ras_n == 0
+    assert pkt.cas_n == 1
+    assert pkt.we_n == 0
+
+
+def test_refresh_encoding_ras_cas_low():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.REF, memory_type=MemoryType.DDR3,
+    )
+    assert pkt.ras_n == 0
+    assert pkt.cas_n == 0
+    assert pkt.we_n == 1
+
+
+def test_mrs_all_three_low():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.MRS, memory_type=MemoryType.DDR3,
+    )
+    assert pkt.ras_n == 0
+    assert pkt.cas_n == 0
+    assert pkt.we_n == 0
+
+
+# ---------------------------------------------------------------------
+# Auto-precharge / all-banks encoded in addr[10]
+# ---------------------------------------------------------------------
+
+
+def test_read_with_auto_precharge_sets_addr_bit10():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.RD, memory_type=MemoryType.DDR3,
+        address=0x40, auto_precharge=True,
+    )
+    assert pkt.address == (0x40 | (1 << 10))
+
+
+def test_read_without_auto_precharge_leaves_addr_bit10_clear():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.RD, memory_type=MemoryType.DDR3,
+        address=0x40, auto_precharge=False,
+    )
+    assert pkt.address == 0x40
+
+
+def test_precharge_all_banks_sets_addr_bit10():
+    pkt = DFIControlPacket.from_command(
+        DRAMCommand.PREA, memory_type=MemoryType.DDR3, all_banks=True,
+    )
+    assert pkt.address & (1 << 10)
+
+
+# ---------------------------------------------------------------------
+# LPDDR2 special-case
+# ---------------------------------------------------------------------
+
+
+def test_lpddr2_command_helper_raises():
+    """LPDDR2 uses the CA encoding instead of the DDR RAS/CAS/WE signals."""
+    with pytest.raises(NotImplementedError, match="LPDDR2"):
+        DFIControlPacket.from_command(
+            DRAMCommand.RD, memory_type=MemoryType.LPDDR2,
+        )
+
+
+# ---------------------------------------------------------------------
+# Default-construct semantics (idle bus state)
+# ---------------------------------------------------------------------
+
+
+def test_default_control_packet_is_idle():
+    """Default values should match the spec's deasserted/idle state."""
+    pkt = DFIControlPacket()
+    assert pkt.cs_n == 1     # CS_n high = no command
+    assert pkt.ras_n == 1
+    assert pkt.cas_n == 1
+    assert pkt.we_n == 1
+    assert pkt.reset_n == 1  # not in reset
+
+
+def test_default_write_data_packet_inactive():
+    pkt = DFIWriteDataPacket()
+    assert pkt.wrdata_en == 0  # data invalid
+
+
+def test_default_read_data_packet_inactive():
+    pkt = DFIReadDataPacket()
+    assert pkt.rddata_valid == 0

--- a/tests/unit/test_dfi_signals.py
+++ b/tests/unit/test_dfi_signals.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import pytest
 
 from CocoTBFramework.components.dfi.dfi_signals import (
+    SUPPORTED_MEMORY_BY_VERSION,
     DFIVersion,
     MemoryType,
     SignalDirection,
+    SignalSpec,
     SubInterface,
     MVP_MEMORY_TYPES,
     MVP_SUB_INTERFACES,
     MVP_VERSIONS,
+    is_supported_pair,
     optional_signal_names,
     required_signal_names,
     signals_for,
@@ -37,9 +40,9 @@ def test_mvp_memory_types_excludes_ddr4_and_lpddr4_plus():
     assert MemoryType.LPDDR5 not in MVP_MEMORY_TYPES
 
 
-def test_mvp_sub_interfaces_is_control_write_read_only():
+def test_mvp_sub_interfaces_is_command_write_read_only():
     assert MVP_SUB_INTERFACES == frozenset({
-        SubInterface.CONTROL,
+        SubInterface.COMMAND,
         SubInterface.WRITE_DATA,
         SubInterface.READ_DATA,
     })
@@ -110,10 +113,10 @@ def test_rddata_dnv_only_on_lpddr2():
 # ---------------------------------------------------------------------
 
 
-def test_control_only_profile_excludes_data_signals():
+def test_command_only_profile_excludes_data_signals():
     sigs = signals_for(
         DFIVersion.V2_1, MemoryType.DDR3,
-        sub_interfaces=frozenset({SubInterface.CONTROL}),
+        sub_interfaces=frozenset({SubInterface.COMMAND}),
     )
     names = {s.name for s in sigs}
     assert "address" in names
@@ -178,10 +181,10 @@ def test_rddata_en_is_mc_to_phy():
     assert sigs["rddata_en"].direction == SignalDirection.MC_TO_PHY
 
 
-def test_all_control_signals_are_mc_to_phy():
+def test_all_command_signals_are_mc_to_phy():
     sigs = signals_for(
         DFIVersion.V2_1, MemoryType.DDR3,
-        sub_interfaces=frozenset({SubInterface.CONTROL}),
+        sub_interfaces=frozenset({SubInterface.COMMAND}),
     )
     assert all(s.direction == SignalDirection.MC_TO_PHY for s in sigs)
 
@@ -217,3 +220,146 @@ def test_validate_rejects_phase2_sub_interface():
             DFIVersion.V2_1, MemoryType.DDR3,
             MVP_SUB_INTERFACES | {SubInterface.TRAINING},
         )
+
+
+# ---------------------------------------------------------------------
+# Per-version memory support matrix (SUPPORTED_MEMORY_BY_VERSION)
+# ---------------------------------------------------------------------
+
+
+def test_v6_drops_legacy_memory_types():
+    """v6.0 changelog: 'Removed DDR/2/3/4 and LPDDR/2/3/4 support'."""
+    v6_support = SUPPORTED_MEMORY_BY_VERSION[DFIVersion.V6_0]
+    for dropped in (MemoryType.DDR1, MemoryType.DDR2, MemoryType.DDR3,
+                    MemoryType.DDR4, MemoryType.LPDDR1, MemoryType.LPDDR2,
+                    MemoryType.LPDDR3, MemoryType.LPDDR4):
+        assert dropped not in v6_support, (
+            f"v6.0 dropped {dropped.value} per spec; matrix still has it"
+        )
+
+
+def test_v6_adds_hbm4_and_lpddr6():
+    v6_support = SUPPORTED_MEMORY_BY_VERSION[DFIVersion.V6_0]
+    assert MemoryType.HBM4 in v6_support
+    assert MemoryType.LPDDR6 in v6_support
+    assert MemoryType.DDR5 in v6_support
+    assert MemoryType.LPDDR5 in v6_support
+
+
+def test_v2_1_doesnt_have_ddr4():
+    """DDR4 was added in v3.0."""
+    assert MemoryType.DDR4 not in SUPPORTED_MEMORY_BY_VERSION[DFIVersion.V2_1]
+
+
+def test_v3_1_adds_ddr4_and_lpddr3():
+    v3_support = SUPPORTED_MEMORY_BY_VERSION[DFIVersion.V3_1]
+    assert MemoryType.DDR4 in v3_support
+    assert MemoryType.LPDDR3 in v3_support
+    # Still has v2.1 legacy
+    assert MemoryType.DDR3 in v3_support
+
+
+def test_v4_0_adds_lpddr4():
+    assert MemoryType.LPDDR4 in SUPPORTED_MEMORY_BY_VERSION[DFIVersion.V4_0]
+
+
+def test_v5_2_adds_ddr5_lpddr5_keeps_legacy():
+    v5_support = SUPPORTED_MEMORY_BY_VERSION[DFIVersion.V5_2]
+    assert MemoryType.DDR5 in v5_support
+    assert MemoryType.LPDDR5 in v5_support
+    # Legacy still supported in v5.x
+    assert MemoryType.DDR3 in v5_support
+
+
+def test_is_supported_pair_matches_matrix():
+    assert is_supported_pair(DFIVersion.V2_1, MemoryType.DDR3)
+    assert not is_supported_pair(DFIVersion.V6_0, MemoryType.DDR3)
+    assert is_supported_pair(DFIVersion.V6_0, MemoryType.HBM4)
+
+
+def test_validate_catches_v6_with_legacy_memory(monkeypatch):
+    """Even after widening MVP to include v6.0 and DDR3, the
+    (version, memory) check must reject incompatible pairs.
+    """
+    # Temporarily widen the MVP gates to simulate Phase-3
+    monkeypatch.setattr(
+        "CocoTBFramework.components.dfi.dfi_signals.MVP_VERSIONS",
+        frozenset({DFIVersion.V2_1, DFIVersion.V6_0}),
+    )
+    monkeypatch.setattr(
+        "CocoTBFramework.components.dfi.dfi_signals.MVP_MEMORY_TYPES",
+        MVP_MEMORY_TYPES | {MemoryType.DDR5},
+    )
+    with pytest.raises(ValueError, match="does not support"):
+        validate_configuration(
+            DFIVersion.V6_0, MemoryType.DDR3, MVP_SUB_INTERFACES,
+        )
+
+
+# ---------------------------------------------------------------------
+# SignalSpec.max_version + applies()
+# ---------------------------------------------------------------------
+
+
+def test_signal_spec_max_version_defaults_to_none():
+    """Default ``max_version`` means signal stays in current spec."""
+    spec = SignalSpec(
+        name="x",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key="data_width",
+        sub_interface=SubInterface.COMMAND,
+        min_version=DFIVersion.V2_1,
+        memory_types=frozenset(),
+        description="test",
+    )
+    assert spec.max_version is None
+
+
+def test_applies_rejects_when_above_max_version():
+    """If a signal is removed in v6.0, ``max_version=V5_2`` excludes v6.0."""
+    spec = SignalSpec(
+        name="legacy",
+        direction=SignalDirection.MC_TO_PHY,
+        width_key="data_width",
+        sub_interface=SubInterface.COMMAND,
+        min_version=DFIVersion.V2_1,
+        max_version=DFIVersion.V5_2,
+        memory_types=frozenset(),
+        description="test",
+    )
+    # Within range
+    assert spec.applies(DFIVersion.V2_1, MemoryType.DDR3)
+    assert spec.applies(DFIVersion.V5_2, MemoryType.DDR3)
+    # Beyond max
+    assert not spec.applies(DFIVersion.V6_0, MemoryType.DDR5)
+
+
+# ---------------------------------------------------------------------
+# Expanded SubInterface + MemoryType enums
+# ---------------------------------------------------------------------
+
+
+def test_sub_interface_enum_covers_v6_interfaces():
+    """v6.0 §3 enumerates 14 distinct interface signal groups (plus
+    TRAINING from v2.1-v5.x). The enum should have all of them."""
+    expected = {
+        SubInterface.COMMAND, SubInterface.WRITE_DATA, SubInterface.READ_DATA,
+        SubInterface.WCK_CONTROL, SubInterface.STATUS, SubInterface.LOW_POWER,
+        SubInterface.UPDATE, SubInterface.PHY_MANAGED,
+        SubInterface.MC_TO_PHY_MSG, SubInterface.PHY_ERROR,
+        SubInterface.DBI, SubInterface.ECC, SubInterface.LINK_CRC,
+        SubInterface.MULTI_CHANNEL,
+        SubInterface.TRAINING,
+    }
+    assert set(SubInterface) == expected
+
+
+def test_memory_type_enum_covers_v6_additions():
+    assert MemoryType.LPDDR6 in set(MemoryType)
+    assert MemoryType.HBM4 in set(MemoryType)
+
+
+def test_control_enum_value_renamed_to_command():
+    """v6.0 calls this the "Command Interface"; we use that name."""
+    assert SubInterface.COMMAND.value == "command"
+    assert not hasattr(SubInterface, "CONTROL")

--- a/tests/unit/test_dfi_signals.py
+++ b/tests/unit/test_dfi_signals.py
@@ -1,0 +1,219 @@
+"""Unit tests for the DFI signal envelope (issue #16)."""
+
+from __future__ import annotations
+
+import pytest
+
+from CocoTBFramework.components.dfi.dfi_signals import (
+    DFIVersion,
+    MemoryType,
+    SignalDirection,
+    SubInterface,
+    MVP_MEMORY_TYPES,
+    MVP_SUB_INTERFACES,
+    MVP_VERSIONS,
+    optional_signal_names,
+    required_signal_names,
+    signals_for,
+    validate_configuration,
+)
+
+
+# ---------------------------------------------------------------------
+# MVP envelope
+# ---------------------------------------------------------------------
+
+
+def test_mvp_versions_is_v21_only():
+    assert MVP_VERSIONS == frozenset({DFIVersion.V2_1})
+
+
+def test_mvp_memory_types_excludes_ddr4_and_lpddr4_plus():
+    """Phase 2 will add these — they should NOT be in the MVP set."""
+    assert MemoryType.DDR4 not in MVP_MEMORY_TYPES
+    assert MemoryType.DDR5 not in MVP_MEMORY_TYPES
+    assert MemoryType.LPDDR3 not in MVP_MEMORY_TYPES
+    assert MemoryType.LPDDR4 not in MVP_MEMORY_TYPES
+    assert MemoryType.LPDDR5 not in MVP_MEMORY_TYPES
+
+
+def test_mvp_sub_interfaces_is_control_write_read_only():
+    assert MVP_SUB_INTERFACES == frozenset({
+        SubInterface.CONTROL,
+        SubInterface.WRITE_DATA,
+        SubInterface.READ_DATA,
+    })
+
+
+# ---------------------------------------------------------------------
+# Signal gating by memory type (matches DFI v2.1 Tables 2/4/6)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("memory_type", [
+    MemoryType.DDR1, MemoryType.LPDDR1, MemoryType.DDR2,
+    MemoryType.DDR3, MemoryType.LPDDR2,
+])
+def test_universal_signals_present_for_all_memory_types(memory_type):
+    """address, cke, cs_n, wrdata, rddata family — always there."""
+    names = {s.name for s in signals_for(DFIVersion.V2_1, memory_type)}
+    for required in ("address", "cke", "cs_n", "wrdata", "wrdata_en",
+                     "wrdata_mask", "rddata", "rddata_en", "rddata_valid"):
+        assert required in names, (
+            f"{required} should be universal but missing for {memory_type.value}"
+        )
+
+
+def test_reset_n_only_on_ddr3():
+    """dfi_reset_n is DDR3-only per Table 2."""
+    for m in (MemoryType.DDR1, MemoryType.DDR2, MemoryType.LPDDR1, MemoryType.LPDDR2):
+        names = {s.name for s in signals_for(DFIVersion.V2_1, m)}
+        assert "reset_n" not in names, f"reset_n should not appear for {m.value}"
+
+    names_ddr3 = {s.name for s in signals_for(DFIVersion.V2_1, MemoryType.DDR3)}
+    assert "reset_n" in names_ddr3
+
+
+def test_odt_only_on_ddr2_and_ddr3():
+    """dfi_odt is DDR2+DDR3 only per Table 2."""
+    for m in (MemoryType.DDR1, MemoryType.LPDDR1, MemoryType.LPDDR2):
+        names = {s.name for s in signals_for(DFIVersion.V2_1, m)}
+        assert "odt" not in names, f"odt should not appear for {m.value}"
+
+    for m in (MemoryType.DDR2, MemoryType.DDR3):
+        names = {s.name for s in signals_for(DFIVersion.V2_1, m)}
+        assert "odt" in names, f"odt should appear for {m.value}"
+
+
+def test_lpddr2_idles_ddr_command_signals():
+    """LPDDR2 doesn't use bank/ras_n/cas_n/we_n (held idle per spec §3.1)."""
+    names = {s.name for s in signals_for(DFIVersion.V2_1, MemoryType.LPDDR2)}
+    for idled in ("bank", "ras_n", "cas_n", "we_n"):
+        assert idled not in names, (
+            f"{idled} should not appear in LPDDR2 envelope (it's held idle)"
+        )
+
+
+def test_rddata_dnv_only_on_lpddr2():
+    """dfi_rddata_dnv is LPDDR2-only per Table 6."""
+    for m in (MemoryType.DDR1, MemoryType.DDR2, MemoryType.DDR3,
+              MemoryType.LPDDR1):
+        names = {s.name for s in signals_for(DFIVersion.V2_1, m)}
+        assert "rddata_dnv" not in names
+
+    names = {s.name for s in signals_for(DFIVersion.V2_1, MemoryType.LPDDR2)}
+    assert "rddata_dnv" in names
+
+
+# ---------------------------------------------------------------------
+# Sub-interface profile selection
+# ---------------------------------------------------------------------
+
+
+def test_control_only_profile_excludes_data_signals():
+    sigs = signals_for(
+        DFIVersion.V2_1, MemoryType.DDR3,
+        sub_interfaces=frozenset({SubInterface.CONTROL}),
+    )
+    names = {s.name for s in sigs}
+    assert "address" in names
+    assert "wrdata" not in names
+    assert "rddata" not in names
+
+
+def test_read_only_profile_has_only_read_signals():
+    sigs = signals_for(
+        DFIVersion.V2_1, MemoryType.DDR3,
+        sub_interfaces=frozenset({SubInterface.READ_DATA}),
+    )
+    names = {s.name for s in sigs}
+    assert names == {"rddata", "rddata_en", "rddata_valid"}
+
+
+# ---------------------------------------------------------------------
+# Signal name helpers (for cocotb_bus._signals / _optional_signals)
+# ---------------------------------------------------------------------
+
+
+def test_required_names_use_dfi_prefix():
+    names = required_signal_names(DFIVersion.V2_1, MemoryType.DDR3)
+    for name in names:
+        assert name.startswith("dfi_")
+
+
+def test_required_names_custom_prefix():
+    names = required_signal_names(DFIVersion.V2_1, MemoryType.DDR3,
+                                   prefix="ch0_dfi")
+    assert all(n.startswith("ch0_dfi_") for n in names)
+
+
+def test_required_holds_universal_signals_only():
+    """Universal signals → _signals; memory-gated → _optional_signals."""
+    req = set(required_signal_names(DFIVersion.V2_1, MemoryType.DDR3))
+    opt = set(optional_signal_names(DFIVersion.V2_1, MemoryType.DDR3))
+    # No overlap
+    assert req.isdisjoint(opt)
+    # Universal-only sample
+    assert "dfi_address" in req
+    assert "dfi_cke" in req
+    # Memory-gated sample
+    assert "dfi_odt" in opt    # DDR2/DDR3
+    assert "dfi_reset_n" in opt  # DDR3
+
+
+# ---------------------------------------------------------------------
+# Direction
+# ---------------------------------------------------------------------
+
+
+def test_rddata_is_phy_to_mc():
+    sigs = {s.name: s for s in signals_for(DFIVersion.V2_1, MemoryType.DDR3)}
+    assert sigs["rddata"].direction == SignalDirection.PHY_TO_MC
+    assert sigs["rddata_valid"].direction == SignalDirection.PHY_TO_MC
+
+
+def test_rddata_en_is_mc_to_phy():
+    sigs = {s.name: s for s in signals_for(DFIVersion.V2_1, MemoryType.DDR3)}
+    # rddata_en is from MC even though it belongs to the read-data interface
+    assert sigs["rddata_en"].direction == SignalDirection.MC_TO_PHY
+
+
+def test_all_control_signals_are_mc_to_phy():
+    sigs = signals_for(
+        DFIVersion.V2_1, MemoryType.DDR3,
+        sub_interfaces=frozenset({SubInterface.CONTROL}),
+    )
+    assert all(s.direction == SignalDirection.MC_TO_PHY for s in sigs)
+
+
+# ---------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------
+
+
+def test_validate_accepts_mvp_combo():
+    validate_configuration(
+        DFIVersion.V2_1, MemoryType.DDR3, MVP_SUB_INTERFACES,
+    )  # no raise
+
+
+def test_validate_rejects_post_mvp_version():
+    with pytest.raises(ValueError, match="Phase 2"):
+        validate_configuration(
+            DFIVersion.V6_0, MemoryType.DDR3, MVP_SUB_INTERFACES,
+        )
+
+
+def test_validate_rejects_post_mvp_memory_type():
+    with pytest.raises(ValueError, match="Phase 2"):
+        validate_configuration(
+            DFIVersion.V2_1, MemoryType.DDR5, MVP_SUB_INTERFACES,
+        )
+
+
+def test_validate_rejects_phase2_sub_interface():
+    with pytest.raises(ValueError, match="Phase 2"):
+        validate_configuration(
+            DFIVersion.V2_1, MemoryType.DDR3,
+            MVP_SUB_INTERFACES | {SubInterface.TRAINING},
+        )

--- a/tests/unit/test_dfi_tfaw.py
+++ b/tests/unit/test_dfi_tfaw.py
@@ -1,0 +1,118 @@
+"""Unit tests for tFAW windowing in DramStateModel (issue #16).
+
+tFAW = Four-Activate Window: no more than 4 ACT commands may issue
+within any rolling tFAW-cycle window. JEDEC enforces this to limit
+peak current draw. The check is "soft" because it's a windowed
+average — a single violation typically warns rather than halts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from CocoTBFramework.components.dfi import (
+    DramStateModel,
+    ViolationPolicy,
+    builtin_timings,
+)
+
+
+@pytest.fixture
+def timings():
+    return builtin_timings("ddr3-1600")  # tFAW = 24 cycles, tRRD = 5 cycles
+
+
+@pytest.fixture
+def model(timings):
+    return DramStateModel(timings=timings, num_banks=8)
+
+
+def _advance(m, n):
+    for _ in range(n):
+        m.tick()
+
+
+# ---------------------------------------------------------------------
+# tFAW happy-path: 4 ACTs spread across the window are OK
+# ---------------------------------------------------------------------
+
+
+def test_three_acts_does_not_trigger_tfaw(model, timings):
+    """tFAW only fires on the *5th* ACT inside the window."""
+    model.on_activate(0, 0x100)
+    _advance(model, timings.tRRD_cycles)
+    model.on_activate(1, 0x100)
+    _advance(model, timings.tRRD_cycles)
+    model.on_activate(2, 0x100)
+    # 3 ACTs is fine — tFAW window only kicks in once 4 ACTs are in flight
+    assert model.policy.soft_violation_counts.get("tFAW", 0) == 0
+
+
+def test_four_acts_outside_window_does_not_warn(model, timings, caplog):
+    """4 ACTs are fine if the 4th lands >= tFAW cycles after the 1st."""
+    spacing = max(timings.tRRD_cycles, (timings.tFAW_cycles // 3) + 1)
+    model.on_activate(0, 0x100)
+    _advance(model, spacing)
+    model.on_activate(1, 0x100)
+    _advance(model, spacing)
+    model.on_activate(2, 0x100)
+    _advance(model, spacing)
+    model.on_activate(3, 0x100)
+    # 4th ACT is far enough out that the rolling tFAW window can hold it
+    assert model.policy.soft_violation_counts.get("tFAW", 0) == 0
+
+
+# ---------------------------------------------------------------------
+# tFAW violation: 5th ACT inside the window
+# ---------------------------------------------------------------------
+
+
+def test_fifth_act_within_window_warns(timings, caplog):
+    """Pack 5 ACTs tighter than tFAW — the 5th must trigger a soft warn."""
+    # Use a logger so the warning is captured
+    log = logging.getLogger("test_tfaw")
+    model = DramStateModel(timings=timings, num_banks=8, log=log)
+    with caplog.at_level(logging.WARNING):
+        # ACT every tRRD cycles → 4 ACTs in 3 * tRRD cycles (well under tFAW)
+        for b in range(4):
+            model.on_activate(b, 0x100)
+            _advance(model, timings.tRRD_cycles)
+        # 5th ACT is still within the tFAW window of the 1st
+        model.on_activate(4, 0x100)
+    assert model.policy.soft_violation_counts.get("tFAW", 0) == 1
+    assert any("tFAW" in r.getMessage() for r in caplog.records)
+
+
+def test_fifth_act_after_window_is_silent(timings):
+    """If the 5th ACT comes after tFAW from ACT #1, the window has rolled."""
+    model = DramStateModel(timings=timings, num_banks=8)
+    # 4 ACTs early
+    for b in range(4):
+        model.on_activate(b, 0x100)
+        _advance(model, timings.tRRD_cycles)
+    # Wait long enough that ACT #1 falls out of the window
+    _advance(model, timings.tFAW_cycles)
+    model.on_activate(5, 0x100)
+    assert model.policy.soft_violation_counts.get("tFAW", 0) == 0
+
+
+# ---------------------------------------------------------------------
+# Policy override: caller can make tFAW hard
+# ---------------------------------------------------------------------
+
+
+def test_tfaw_can_be_promoted_to_hard(timings):
+    """Caller can override the default and make tFAW fatal."""
+    policy = ViolationPolicy(
+        hard=frozenset({"tFAW"}),
+        soft=frozenset(),
+        ignore=frozenset(),
+    )
+    model = DramStateModel(timings=timings, num_banks=8, policy=policy)
+    for b in range(4):
+        model.on_activate(b, 0x100)
+        _advance(model, timings.tRRD_cycles)
+    with pytest.raises(AssertionError, match="tFAW"):
+        model.on_activate(4, 0x100)


### PR DESCRIPTION
Lands the DFI v2.1 BFM MVP. Eight commits build up the stack from signal envelope through JEDEC timing checker, DRAM state model, wire passthrough, master/slave/monitor classes, to an end-to-end loopback test where the master writes a row through a SystemVerilog shim and the slave numpy-backed memory model serves the reads back.

**Not for PyPI release yet** — checkpoint PR so review can happen before multi-beat (BL=8) and Phase 2 sub-interfaces land.

## Test scoreboard

| Tier | Tests | Status |
|---|---|---|
| Tier 1 unit (pytest) | 249 | green |
| Tier 2 cocotb sim | 3 across 2 builds | green |

## What works

- DFI v2.1 + DDR1/2/3/LPDDR1/2 envelope
- JEDEC timing checker: 8 hard timings + 5 bank-state transitions, plus tFAW soft check
- Two reference JEDEC CSVs: DDR3-1600 and DDR2-650 (Micron MT47H64M16HR-25:H on Digilent FPGA board)
- DRAMsim3-style late-binding flat to (rank, bank, row, col) address decoder
- dfi_shim.sv passthrough (15 signals) for round-trip verification
- Master primitive API: activate / read / write / write_data / precharge / refresh / nop
- Slave queues reads behind in-flight writes, auto-commits writes after CWL

## What is deliberately NOT here

- Multi-beat bursts (BL=4/8) — MVP runs BL=1 conceptually. Follow-up PR.
- Auto-precharge servicing — slave logs but does not yet act on address[10].
- Phase 2 sub-interfaces (update / status / training).

## Test plan

- [x] pytest tests/unit/ (249 pass)
- [x] pytest tests/sim/dfi/ (both green)
- [x] Sanity check: deliberately broken assertions fail cleanly
- [ ] Multi-beat BL=8 lands as follow-up PR before any PyPI release