### PR TITLE
feat(dfi): BL=8 multi-beat burst support (issue #16)

### DIFF
--- a/src/CocoTBFramework/components/dfi/dfi_base.py
+++ b/src/CocoTBFramework/components/dfi/dfi_base.py
@@ -67,6 +67,7 @@ class DFIBase:
         timings: JedecTimings,
         mapping: AddressMapping,
         sub_interfaces: Optional[FrozenSet[SubInterface]] = None,
+        beats_per_burst: Optional[int] = None,
     ):
         if not is_supported_pair(dfi_version, memory_type):
             raise ValueError(
@@ -82,6 +83,17 @@ class DFIBase:
         self.enabled_sub_interfaces: FrozenSet[SubInterface] = (
             sub_interfaces if sub_interfaces is not None else MVP_SUB_INTERFACES
         )
+        # DFI beats per DRAM burst. Default = BL // 2 — assumes the
+        # canonical K=2 PHY-to-DRAM ratio (e.g., a 32-bit DFI data path
+        # for an x16 DRAM). Override for K=1 (beats_per_burst=BL) or for
+        # the BFM-MVP BL=1 case where one DFI beat == one DRAM burst.
+        if beats_per_burst is None:
+            beats_per_burst = max(1, timings.BL // 2)
+        if beats_per_burst <= 0:
+            raise ValueError(
+                f"beats_per_burst must be positive, got {beats_per_burst}"
+            )
+        self.beats_per_burst = beats_per_burst
         self.cycle = 0
 
     # ----- Cycle accounting -----

--- a/src/CocoTBFramework/components/dfi/dfi_master_mc.py
+++ b/src/CocoTBFramework/components/dfi/dfi_master_mc.py
@@ -150,7 +150,7 @@ class DFIMasterMC(BusDriver):
         for _ in range(cycles):
             await RisingEdge(self.clock)
 
-    # ----- Write-data-interface primitive -----
+    # ----- Write-data-interface primitives -----
 
     async def write_data(self, data: int, mask: int = 0) -> None:
         """Drive one beat of write data on the next clock edge."""
@@ -159,6 +159,31 @@ class DFIMasterMC(BusDriver):
         self.bus.wrdata_en.value = 1
         await RisingEdge(self.clock)
         self.bus.wrdata_en.value = 0
+
+    async def write_burst(self, beats, masks=None) -> None:
+        """Drive a burst of consecutive write-data beats.
+
+        For BL=8 with the canonical K=2 PHY ratio this is 4 beats; for
+        BL=1 (the MVP-loopback case) it's just 1. The slave's
+        DFISlavePHY queues writes at consecutive flat addresses
+        (col, col+1, …, col+N-1) starting from the WR command's col.
+
+        Args:
+            beats: iterable of ints, one per DFI beat.
+            masks: optional iterable of mask ints; defaults to 0 (no mask)
+                   for every beat.
+        """
+        beats = list(beats)
+        if masks is None:
+            masks = [0] * len(beats)
+        else:
+            masks = list(masks)
+            if len(masks) != len(beats):
+                raise ValueError(
+                    f"masks length {len(masks)} != beats length {len(beats)}"
+                )
+        for data, mask in zip(beats, masks):
+            await self.write_data(data, mask)
 
     # ----- Read-data hint -----
 

--- a/src/CocoTBFramework/components/dfi/dfi_slave_phy.py
+++ b/src/CocoTBFramework/components/dfi/dfi_slave_phy.py
@@ -149,19 +149,38 @@ class DFISlavePHY(BusMonitor):
 
         self.cmd_counts[cmd] = self.cmd_counts.get(cmd, 0) + 1
 
+        beats = self.base.beats_per_burst
+
         if cmd == DRAMCommand.ACT:
             self.dram.on_activate(bank_idx=bank, row=addr)
         elif cmd == DRAMCommand.RD:
             self.dram.on_read(bank_idx=bank)
-            flat = self._flat_addr_for(bank, addr)
-            self._pending_reads.append(_PendingOp(due_cycle=cycle + cl, flat_addr=flat))
+            base_col = addr & self._col_mask
+            open_row = self.dram.banks[bank].row or 0
+            # Queue N consecutive beats at (col, col+1, …, col+N-1).
+            # Each beat lands one DFI cycle after the previous.
+            for k in range(beats):
+                col_k = base_col + k
+                if col_k >= self.mapping.num_cols:
+                    break  # don't wrap past the row end for now
+                flat = self.mapping.tuple_to_flat(0, bank, open_row, col_k)
+                self._pending_reads.append(
+                    _PendingOp(due_cycle=cycle + cl + k, flat_addr=flat)
+                )
             if addr & (1 << 10):
-                # Auto-precharge after the read
                 self._pending_auto_pre(bank)
         elif cmd == DRAMCommand.WR:
             self.dram.on_write(bank_idx=bank)
-            flat = self._flat_addr_for(bank, addr)
-            self._pending_writes.append(_PendingOp(due_cycle=cycle + cwl, flat_addr=flat))
+            base_col = addr & self._col_mask
+            open_row = self.dram.banks[bank].row or 0
+            for k in range(beats):
+                col_k = base_col + k
+                if col_k >= self.mapping.num_cols:
+                    break
+                flat = self.mapping.tuple_to_flat(0, bank, open_row, col_k)
+                self._pending_writes.append(
+                    _PendingOp(due_cycle=cycle + cwl + k, flat_addr=flat)
+                )
             if addr & (1 << 10):
                 self._pending_auto_pre(bank)
         elif cmd == DRAMCommand.PRE:

--- a/tests/sim/dfi/test_dfi_bl8.py
+++ b/tests/sim/dfi/test_dfi_bl8.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2024-2026 sean galloway
+
+"""Tier 2 sim test: DDR3 BL=8 multi-beat round-trip (issue #16).
+
+DDR3-1600 has BL=8 and the canonical DFI v2.1 PHY ratio is K=2 (DFI
+data path is 2× the DRAM data path), so each WR / RD command transfers
+4 DFI beats to/from consecutive columns. This test verifies:
+
+  - DFIMasterMC.write_burst() drives N beats over N consecutive cycles
+  - DFISlavePHY queues N consecutive writes at cols (C, C+1, …, C+N-1)
+    starting CWL cycles after the WR command
+  - DFISlavePHY drives N consecutive read beats at cols (C, C+1, …)
+    starting CL cycles after the RD command
+  - DFIMonitor on the PHY side captures all N beats correctly per
+    burst
+"""
+
+from __future__ import annotations
+
+import os
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+from cocotb_test.simulator import run
+
+from CocoTBFramework.components.dfi import (
+    AddressMapping,
+    DFIBase,
+    DFIMasterMC,
+    DFIMonitor,
+    DFIVersion,
+    MemoryType,
+    builtin_timings,
+)
+from CocoTBFramework.components.dfi.dfi_slave_phy import DFISlavePHY
+from CocoTBFramework.components.shared.memory_model import MemoryModel
+
+
+# 4 banks × 16 rows × 64 cols × 8 bytes/beat = 32 KiB total.
+# 64 cols gives us room for several 4-beat bursts per row.
+BANKS = 4
+ROWS = 16
+COLS = 64
+BYTES_PER_BEAT = 8
+NUM_LINES = BANKS * ROWS * COLS
+
+
+async def _bring_up(dut):
+    cocotb.start_soon(Clock(dut.dfi_clk, 10, units="ns").start())
+    dut.dfi_rstn.value = 0
+    dut.phy_dfi_rddata.value = 0
+    dut.phy_dfi_rddata_valid.value = 0
+    await RisingEdge(dut.dfi_clk)
+    await RisingEdge(dut.dfi_clk)
+    dut.dfi_rstn.value = 1
+    await RisingEdge(dut.dfi_clk)
+
+
+def _make_slave_stack(dut):
+    timings = builtin_timings("ddr3-1600")  # BL=8 → default beats=4
+    mapping = AddressMapping(
+        num_ranks=1, num_banks=BANKS, num_rows=ROWS, num_cols=COLS,
+    )
+    base = DFIBase(
+        dfi_version=DFIVersion.V2_1,
+        memory_type=MemoryType.DDR3,
+        timings=timings,
+        mapping=mapping,
+    )
+    assert base.beats_per_burst == 4, "expected default beats=4 for DDR3 BL=8"
+    memory = MemoryModel(num_lines=NUM_LINES, bytes_per_line=BYTES_PER_BEAT)
+    slave = DFISlavePHY(dut, dut.dfi_clk, base=base, memory=memory)
+    return base, memory, slave
+
+
+@cocotb.test(timeout_time=5, timeout_unit="ms")
+async def dfi_bl8_burst_test(dut):
+    """Two 4-beat bursts: WR then RD, both at bank=2, starting col=8."""
+    await _bring_up(dut)
+
+    master = DFIMasterMC(dut, dut.dfi_clk)
+    base, memory, slave = _make_slave_stack(dut)
+    phy_mon = DFIMonitor(dut, dut.dfi_clk, side="phy", title="PHY-mon")
+    master.set_rddata_en(1)
+    await Timer(1, units="ns")
+
+    cwl = base.timings.CWL
+    cl  = base.timings.CL
+    trcd = base.timings.tRCD_cycles
+    beats = base.beats_per_burst  # 4
+
+    # Open bank 2, row 0x4
+    await master.activate(bank=2, row=0x4)
+    await master.nop(trcd)
+
+    # ----- Burst 1: WR @ col=8 with 4 distinct beat values -----
+    payloads_a = [0xA0A0_A0A0_0000_0001,
+                  0xA0A0_A0A0_0000_0002,
+                  0xA0A0_A0A0_0000_0003,
+                  0xA0A0_A0A0_0000_0004]
+    await master.write(bank=2, col=8)
+    await master.nop(cwl - 1)
+    await master.write_burst(payloads_a)
+    await master.nop(beats + 4)  # tWTR-ish drain
+
+    # ----- Burst 2: WR @ col=16 -----
+    payloads_b = [0xB0B0_B0B0_0000_0010,
+                  0xB0B0_B0B0_0000_0020,
+                  0xB0B0_B0B0_0000_0030,
+                  0xB0B0_B0B0_0000_0040]
+    await master.write(bank=2, col=16)
+    await master.nop(cwl - 1)
+    await master.write_burst(payloads_b)
+    await master.nop(beats + 6)
+
+    # ----- RD bursts -----
+    # The slave queues 4 reads per RD command; the PHY-side monitor
+    # captures every beat that comes back on rddata_valid.
+    pre_count = phy_mon.read_data_count
+    await master.read(bank=2, col=8)
+    await master.nop(cl + beats + 4)  # wait for the 4-beat response + slack
+
+    await master.read(bank=2, col=16)
+    await master.nop(cl + beats + 4)
+
+    # Drain
+    await master.nop(beats + 8)
+
+    dut._log.info(f"slave: {slave}")
+    dut._log.info(f"phy_mon: {phy_mon}")
+
+    # ----- Assertions -----
+
+    # 8 writes committed (4 beats × 2 bursts), 8 reads served
+    assert slave.writes_committed == 8, (
+        f"expected 8 writes committed, got {slave.writes_committed}"
+    )
+    assert slave.reads_served == 8, (
+        f"expected 8 reads served, got {slave.reads_served}"
+    )
+
+    # Memory contents: 8 beats at cols 8..11 and 16..19
+    expected = {**{8 + i: payloads_a[i] for i in range(4)},
+                **{16 + i: payloads_b[i] for i in range(4)}}
+    for col, want in expected.items():
+        flat = base.mapping.tuple_to_flat(0, 2, 0x4, col)
+        ba = memory.read(flat * BYTES_PER_BEAT, BYTES_PER_BEAT)
+        got = memory.bytearray_to_integer(ba)
+        assert got == want, (
+            f"memory[bank=2 col=0x{col:x}] got 0x{got:x} expected 0x{want:x}"
+        )
+
+    # PHY monitor saw all 8 read beats in the right order
+    captured = [b.rddata for b in list(phy_mon.read_data_q)[pre_count:]]
+    expected_seq = payloads_a + payloads_b
+    assert captured == expected_seq, (
+        f"captured rddata sequence mismatch\n"
+        f"  got     : {[hex(x) for x in captured]}\n"
+        f"  expected: {[hex(x) for x in expected_seq]}"
+    )
+
+    dut._log.info("BL=8 multi-beat round-trip passed (8 writes / 8 reads)")
+
+
+# ---------------------------------------------------------------------
+# Pytest runner
+# ---------------------------------------------------------------------
+
+
+def test_dfi_bl8(request):
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    )
+    test_name = "test_dfi_bl8"
+    sim_build = os.path.join(repo_root, "tests", "sim", "local_sim_build", test_name)
+    log_dir = os.path.join(repo_root, "tests", "sim", "logs")
+    os.makedirs(sim_build, exist_ok=True)
+    os.makedirs(log_dir, exist_ok=True)
+
+    verilog_sources = [
+        os.path.join(repo_root, "tests", "sim", "rtl", "dfi", "dfi_shim.sv"),
+    ]
+    extra_env = {
+        "COCOTB_LOG_LEVEL": "INFO",
+        "COCOTB_RESULTS_FILE": os.path.join(log_dir, f"results_{test_name}.xml"),
+    }
+    extra_args = [
+        "-Wno-TIMESCALEMOD",
+        "-Wno-UNUSED",
+        "-Wno-DECLFILENAME",
+    ]
+
+    run(
+        python_search=[os.path.dirname(__file__)],
+        verilog_sources=verilog_sources,
+        toplevel="dfi_shim",
+        module="test_dfi_bl8",
+        sim_build=sim_build,
+        extra_env=extra_env,
+        extra_args=extra_args,
+        timescale="1ns/1ps",
+        waves=bool(int(os.environ.get("WAVES", "0"))),
+    )

--- a/tests/sim/dfi/test_dfi_loopback.py
+++ b/tests/sim/dfi/test_dfi_loopback.py
@@ -66,11 +66,15 @@ def _make_slave_stack(dut):
     mapping = AddressMapping(
         num_ranks=1, num_banks=BANKS, num_rows=ROWS, num_cols=COLS,
     )
+    # MVP loopback runs BL=1 conceptually — one DFI beat per command.
+    # Pinning explicitly so the test stays valid when DFIBase's default
+    # changes (default now derives from JEDEC BL).
     base = DFIBase(
         dfi_version=DFIVersion.V2_1,
         memory_type=MemoryType.DDR3,
         timings=timings,
         mapping=mapping,
+        beats_per_burst=1,
     )
     memory = MemoryModel(num_lines=NUM_LINES, bytes_per_line=BYTES_PER_BEAT)
     slave = DFISlavePHY(dut, dut.dfi_clk, base=base, memory=memory)

--- a/tests/unit/test_dfi_beats_per_burst.py
+++ b/tests/unit/test_dfi_beats_per_burst.py
@@ -1,0 +1,67 @@
+"""Unit tests for the DFIBase.beats_per_burst field (issue #16, BL=8 phase)."""
+
+from __future__ import annotations
+
+import pytest
+
+from CocoTBFramework.components.dfi import (
+    AddressMapping,
+    DFIBase,
+    DFIVersion,
+    MemoryType,
+    builtin_timings,
+)
+
+
+@pytest.fixture
+def mapping():
+    return AddressMapping(num_ranks=1, num_banks=8, num_rows=8192, num_cols=1024)
+
+
+@pytest.fixture
+def ddr3_timings():
+    return builtin_timings("ddr3-1600")  # BL=8
+
+
+@pytest.fixture
+def ddr2_timings():
+    return builtin_timings("ddr2-650-mt47h64m16hr")  # BL=4
+
+
+def _make(timings, mapping, **kw):
+    return DFIBase(
+        dfi_version=DFIVersion.V2_1,
+        memory_type=MemoryType.DDR3,
+        timings=timings,
+        mapping=mapping,
+        **kw,
+    )
+
+
+def test_default_beats_per_burst_is_BL_over_2(ddr3_timings, mapping):
+    """K=2 PHY ratio: DDR3-1600 BL=8 → 4 DFI beats per DRAM burst."""
+    base = _make(ddr3_timings, mapping)
+    assert base.beats_per_burst == 4
+
+
+def test_default_for_BL4_is_2(ddr2_timings, mapping):
+    """DDR2-650 has BL=4 → 2 DFI beats per DRAM burst by default."""
+    base = _make(ddr2_timings, mapping)
+    assert base.beats_per_burst == 2
+
+
+def test_explicit_override_to_1_for_mvp(ddr3_timings, mapping):
+    """The MVP loopback test wants BL=1 conceptually — one DFI beat per command."""
+    base = _make(ddr3_timings, mapping, beats_per_burst=1)
+    assert base.beats_per_burst == 1
+
+
+def test_explicit_override_to_8_for_K1_phy(ddr3_timings, mapping):
+    """K=1 PHY (DFI bus = DRAM bus width) → beats_per_burst == BL."""
+    base = _make(ddr3_timings, mapping, beats_per_burst=8)
+    assert base.beats_per_burst == 8
+
+
+def test_rejects_zero_beats(ddr3_timings, mapping):
+    with pytest.raises(ValueError, match="beats_per_burst"):
+        _make(ddr3_timings, mapping, beats_per_burst=0)


### PR DESCRIPTION
Stacks on top of #18 (DFI MVP). Extends from BL=1 conceptual to real DDR3 BL=8 with the canonical K=2 PHY ratio (4 DFI beats per DRAM burst).

Not for PyPI yet — same checkpoint approach as #18.

## Changes

**DFIBase** — new `beats_per_burst` field; default derives from `JedecTimings.BL // 2`. Overridable for K=1 (BL beats) or BL=1 MVP (1 beat per command).

**DFIMasterMC** — `write_burst(beats, masks=None)` drives N consecutive write-data beats over N cycles; reuses `write_data()` per beat.

**DFISlavePHY** — On WR: queues N writes at cols (C, C+1, …, C+N-1), each due CWL+k cycles later. On RD: same shape, due CL+k cycles later. End-of-row guard if base_col + k >= num_cols.

## Tests

- `test_dfi_loopback.py`: pinned to `beats_per_burst=1` explicitly so the existing BL=1 round-trip stays valid as the default shifts to 4.
- `test_dfi_bl8.py` (new): two 4-beat WR bursts then two 4-beat RD bursts. Verifies 8 writes committed, 8 reads served, memory contents correct, PHY monitor captured the 8 read beats in order.
- `test_dfi_beats_per_burst.py` (Tier 1, new): 5 tests covering default, DDR2 BL=4 → 2 beats, explicit overrides, zero-beat rejection.

## Scoreboard

| Tier | Tests | Status |
|---|---|---|
| Tier 1 unit | 254 (+5) | green |
| Tier 2 cocotb | 4 (+1) across 3 sim builds | green |

## Test plan

- [x] pytest tests/unit/
- [x] pytest tests/sim/dfi/
- [x] Sanity check: deliberately broken assertion fails cleanly
- [ ] After merge with #18: multi-beat wrap-around (col base_col+k exceeds num_cols) — needs proper DDR-style col toggle order
- [ ] After merge with #18: auto-precharge servicing

## Summary by Sourcery

Add configurable DFI beats-per-burst support and implement multi-beat DDR3 BL=8 burst handling across the DFI base, master, and PHY components.

New Features:
- Introduce DFIBase.beats_per_burst configuration with sensible defaults derived from JEDEC burst length and overrides for alternative PHY ratios and MVP mode.
- Add DFIMasterMC.write_burst helper to drive multi-beat write data bursts over consecutive DFI cycles.
- Extend DFISlavePHY to model multi-beat read and write bursts across consecutive DRAM columns based on beats_per_burst.

Tests:
- Pin existing DFI loopback simulation to beats_per_burst=1 to preserve the BL=1 MVP behavior under the new default.
- Add Tier 2 cocotb simulation test validating DDR3-1600 BL=8 multi-beat write/read bursts and PHY monitor capture ordering.
- Add unit tests for DFIBase.beats_per_burst defaulting, explicit overrides, and invalid configuration handling.